### PR TITLE
Add wrappers for vtkImageData/vtkRectilinearGrids and a whole lot more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,36 +1,42 @@
 vtki
 ====
-..
-   PyPi
+
 .. image:: https://img.shields.io/pypi/v/vtki.svg
-    :target: https://pypi.org/project/vtki/
+   :target: https://pypi.org/project/vtki/
 
 .. image:: https://travis-ci.org/akaszynski/vtki.svg?branch=master
-    :target: https://travis-ci.org/akaszynski/vtki
+   :target: https://travis-ci.org/akaszynski/vtki
 
-.. image:: https://readthedocs.org/projects/vtkInterface/badge/?version=latest
-    :target: https://vtkInterface.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/vtkinterface/badge/?version=latest
+   :target: https://vtkinterface.readthedocs.io/en/latest/?badge=latest
 
-vtki is a VTK helper module that takes a different approach on interfacing with VTK through numpy and direct array access.  This module simplifies mesh creation and plotting by adding functionality to existing VTK objects.
+``vtki`` is a VTK helper module that takes a different approach on interfacing
+with VTK through numpy and direct array access.  This module simplifies mesh
+creation and plotting by adding functionality to existing VTK objects.
 
-This module can be used for scientific plotting for presentations and research papers as well as a supporting module for other mesh dependent Python modules.
+This module can be used for scientific plotting for presentations and research
+papers as well as a supporting module for other mesh dependent Python modules.
 
 
 Documentation
 -------------
-Refer to the detailed `readthedocs <http://vtkInterface.readthedocs.io/en/latest/index.html>`_ documentation for detailed installation and usage details.
+Refer to the detailed `readthedocs <http://vtkInterface.readthedocs.io/en/latest/index.html>`_
+documentation for detailed installation and usage details.
 
-Also see the `wiki <https://github.com/akaszynski/vtki/wiki>`_ for brief code snippets.
+Also see the `wiki <https://github.com/akaszynski/vtki/wiki>`_ for brief code
+snippets.
 
 Installation
 ------------
 Installation is simply::
 
     pip install vtki
-    
-You can also visit `PyPi <http://pypi.python.org/pypi/vtki>`_ or `GitHub <https://github.com/akaszynski/vtki>`_ to download the source.
 
-See the `Installation <http://vtkInterface.readthedocs.io/en/latest/installation.html#install-ref.>`_ for more details if the installation through pip doesn't work out.
+You can also visit `PyPi <http://pypi.python.org/pypi/vtki>`_ or
+`GitHub <https://github.com/akaszynski/vtki>`_ to download the source.
+
+See the `Installation <http://vtkInterface.readthedocs.io/en/latest/installation.html#install-ref.>`_
+for more details if the installation through pip doesn't work out.
 
 
 Quick Examples
@@ -53,7 +59,7 @@ In fact, the code to generate the previous screenshot was created in one line wi
 
     mesh.plot(screenshot='airplane.png', color='orange')
 
-The points and faces from the mesh are directly accessible as a numpy array:
+The points and faces from the mesh are directly accessible as a NumPy array:
 
 .. code:: python
 
@@ -61,11 +67,11 @@ The points and faces from the mesh are directly accessible as a numpy array:
     [[ 896.99401855   48.76010132   82.26560211]
      [ 906.59301758   48.76010132   80.74520111]
      [ 907.53900146   55.49020004   83.65809631]
-     ..., 
+     ...,
      [ 806.66497803  627.36297607    5.11482   ]
      [ 806.66497803  654.43200684    7.51997995]
      [ 806.66497803  681.5369873     9.48744011]]
-    
+
 .. code:: python
 
     >>> faces = mesh.faces.reshape(-1, 4)
@@ -73,15 +79,16 @@ The points and faces from the mesh are directly accessible as a numpy array:
     [[   0    1    2]
      [   0    2    3]
      [   4    5    1]
-     ..., 
+     ...,
      [1324 1333 1323]
      [1325 1216 1334]
      [1325 1334 1324]]
-    
-    
+
+
 Creating a Structured Surface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This example creates a simple surface grid and plots the resulting grid and its curvature:
+This example creates a simple surface grid and plots the resulting grid and its
+curvature:
 
 .. code:: python
 
@@ -94,11 +101,11 @@ This example creates a simple surface grid and plots the resulting grid and its 
     x, y = np.meshgrid(x, y)
     r = np.sqrt(x**2 + y**2)
     z = np.sin(r)
-    
+
     # create and plot structured grid
     grid = vtki.StructuredGrid(x, y, z)
     grid.plot()  # basic plot
-    
+
     # Plot mean curvature
     grid.plot_curvature()
 
@@ -106,7 +113,8 @@ This example creates a simple surface grid and plots the resulting grid and its 
     :width: 500pt
 
 
-Generating a structured grid is a one liner in this module, and the points from the resulting surface are also a numpy array:
+Generating a structured grid is a one liner in this module, and the points from
+the resulting surface are also a NumPy array:
 
 .. code:: python
 
@@ -114,7 +122,7 @@ Generating a structured grid is a one liner in this module, and the points from 
     [[-10.         -10.           0.99998766]
      [ -9.75       -10.           0.98546793]
      [ -9.5        -10.           0.9413954 ]
-     ..., 
+     ...,
      [  9.25         9.75         0.76645876]
      [  9.5          9.75         0.86571785]
      [  9.75         9.75         0.93985707]]
@@ -122,10 +130,11 @@ Generating a structured grid is a one liner in this module, and the points from 
 
 Creating a GIF Movie
 ~~~~~~~~~~~~~~~~~~~~
-This example shows the versatility of the plotting object by generating a moving gif:
+This example shows the versatility of the plotting object by generating a moving
+gif:
 
 .. code:: python
-    
+
     import vtki
     import numpy as np
 
@@ -156,7 +165,7 @@ This example shows the versatility of the plotting object by generating a moving
         z = np.sin(r + phase)
         pts[:, -1] = z.ravel()
         plotter.update_coordinates(pts)
-        plotter.update_scalars(z.ravel())    
+        plotter.update_scalars(z.ravel())
         plotter.write_frame()
 
     # Close movie and delete object

--- a/vtki/__init__.py
+++ b/vtki/__init__.py
@@ -18,6 +18,7 @@ from vtki.grid import Grid
 from vtki.grid import RectilinearGrid
 from vtki.grid import UniformGrid
 from vtki.geometric_objects import *
+from vtki.examples import *
 
 import numpy as np
 

--- a/vtki/__init__.py
+++ b/vtki/__init__.py
@@ -15,6 +15,8 @@ from vtki.polydata import PolyData
 from vtki.grid import UnstructuredGrid
 from vtki.grid import StructuredGrid
 from vtki.grid import Grid
+from vtki.grid import RectilinearGrid
+from vtki.grid import UniformGrid
 from vtki.geometric_objects import *
 
 import numpy as np

--- a/vtki/__init__.py
+++ b/vtki/__init__.py
@@ -18,7 +18,6 @@ from vtki.grid import Grid
 from vtki.grid import RectilinearGrid
 from vtki.grid import UniformGrid
 from vtki.geometric_objects import *
-from vtki.examples import *
 
 import numpy as np
 

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -419,6 +419,60 @@ class Common(object):
     def get_number_of_scalars(self):
         return self.GetPointData().GetNumberOfArrays() + self.GetCellData().GetNumberOfArrays()
 
+    def _get_attrs(self):
+        """An internal helper for the representation methods"""
+        attrs = []
+        #attrs.append(("Dimensions", self.GetDimensions()))
+        attrs.append(("N Cells", self.GetNumberOfCells()))
+        attrs.append(("N Points", self.GetNumberOfPoints()))
+        bds = self.GetBounds()
+        attrs.append(("X Bounds", (bds[0], bds[1])))
+        attrs.append(("Y Bounds", (bds[2], bds[3])))
+        attrs.append(("Z Bounds", (bds[4], bds[5])))
+        return attrs
+
+    def _repr_html_(self):
+        """A pretty representation for Jupyter notebooks"""
+        fmt = ""
+        if self.get_number_of_scalars() > 0:
+            fmt += "<table>"
+            fmt += "<tr><th>Attributes</th><th>Data Arrays</th></tr>"
+            fmt += "<tr><td>"
+        fmt += "\n"
+        fmt += "<table>\n"
+        fmt += "<tr><th>Attribute</th><th>Values</th></tr>\n"
+        row = "<tr><td>{}</td><td>{}</td></tr>\n"
+
+        # now make a call on the object to get its attributes as a list of len 2 tuples
+        for attr in self._get_attrs():
+            fmt += row.format(attr[0], attr[1])
+
+        fmt += "</table>\n"
+        fmt += "\n"
+        if self.get_number_of_scalars() > 0:
+            fmt += "</td><td>"
+            fmt += "\n"
+            fmt += "<table>\n"
+            row = "<tr><th>{}</th><th>{}</th><th>{}</th><th>{}</th><th>{}</th></tr>\n"
+            fmt += row.format("Name", "Field", "Type", "Min", "Max")
+            row = "<tr><td>{}</td><td>{}</td><td>{}</td><td>{:.3e}</td><td>{:.3e}</td></tr>\n"
+
+            def format_array(key, field):
+                arr = get_scalar(self, key)
+                dl, dh = self.get_data_range(key)
+                return row.format(key, field, arr.dtype, dl, dh)
+
+            for i in range(self.GetPointData().GetNumberOfArrays()):
+                key = self.GetPointData().GetArrayName(i)
+                fmt += format_array(key, field='Points')
+            for i in range(self.GetCellData().GetNumberOfArrays()):
+                key = self.GetCellData().GetArrayName(i)
+                fmt += format_array(key, field='Cells')
+            fmt += "</table>\n"
+            fmt += "\n"
+            fmt += "</td></tr> </table>"
+        return fmt
+
 
 class CellScalarsDict(dict):
     """

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -13,10 +13,12 @@ log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')
 
 import vtki
+from vtki.utilities import get_scalar
 
 
 class Common(object):
     """ Methods in common to grid and surface objects"""
+    _is_vtki = True
 
     def __init__(self, *args, **kwargs):
         self.references = []
@@ -78,7 +80,7 @@ class Common(object):
 
         """
         if not isinstance(scalars, np.ndarray):
-            raise TypeError('Input must be a numpy.ndarray') 
+            raise TypeError('Input must be a numpy.ndarray')
 
         if scalars.shape[0] != self.number_of_points:
             raise Exception('Number of scalars must match the number of ' +
@@ -409,6 +411,13 @@ class Common(object):
 
     # def __del__(self):
     #     log.debug('Object collected')
+
+    def get_data_range(self, name):
+        arr = get_scalar(self, name)
+        return np.nanmin(arr), np.nanmax(arr)
+
+    def get_number_of_scalars(self):
+        return self.GetPointData().GetNumberOfArrays() + self.GetCellData().GetNumberOfArrays()
 
 
 class CellScalarsDict(dict):

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -5,7 +5,7 @@ import os
 import logging
 
 import vtk
-from vtk import vtkUnstructuredGrid, vtkStructuredGrid
+from vtk import vtkUnstructuredGrid, vtkStructuredGrid, vtkRectilinearGrid, vtkImageData
 from vtk.util.numpy_support import vtk_to_numpy, numpy_to_vtkIdTypeArray
 from vtk.util.numpy_support import numpy_to_vtk
 from vtk import VTK_TRIANGLE
@@ -259,7 +259,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, Grid):
         >>> points = np.vstack((cell1, cell2))
 
         >>> grid = vtki.UnstructuredGrid(offset, cells, cell_type, points)
-        
+
         """
 
         if offset.dtype != vtki.ID_TYPE:
@@ -525,14 +525,14 @@ class UnstructuredGrid(vtkUnstructuredGrid, Grid):
             Grids to merge to this grid.
 
         merge_points : bool, optional
-            Points in exactly the same location will be merged between 
+            Points in exactly the same location will be merged between
             the two meshes.
 
         inplace : bool, optional
             Updates grid inplace when True.
 
         main_has_priority : bool, optional
-            When this parameter is true and merge_points is true, 
+            When this parameter is true and merge_points is true,
             the scalar arrays of the merging grids will be overwritten
             by the original main mesh.
 
@@ -756,3 +756,432 @@ class StructuredGrid(vtkStructuredGrid, Grid):
 
         """
         return UnstructuredGrid(self).quality
+
+
+class RectilinearGrid(vtkRectilinearGrid, Grid):
+    """
+    Extends the functionality of a vtk.vtkRectilinearGrid object
+    Can be initialized in several ways:
+
+    - Create empty grid
+    - Initialize from a vtk.vtkRectilinearGrid object
+    - Initialize directly from the point arrays
+
+    See _from_arrays in the documentation for more details on initializing
+    from point arrays
+
+    Examples
+    --------
+    >>> grid = RectilinearGrid()  # Create empty grid
+    >>> grid = RectilinearGrid(vtkgrid)  # Initialize from a vtk.vtkRectilinearGrid object
+    >>> xrng = np.arange(-10, 10, 2)
+    >>> yrng = np.arange(-10, 10, 5)
+    >>> zrng = np.arange(-10, 10, 1)
+    >>> grid = vtki.RectilinearGrid(xrng, yrng, zrng)
+
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(RectilinearGrid, self).__init__()
+
+        if len(args) == 1:
+            if isinstance(args[0], vtk.vtkRectilinearGrid):
+                self.DeepCopy(args[0])
+            elif isinstance(args[0], str):
+                self._load_file(args[0])
+
+        elif len(args) == 3:
+            arg0_is_arr = isinstance(args[0], np.ndarray)
+            arg1_is_arr = isinstance(args[1], np.ndarray)
+            arg2_is_arr = isinstance(args[2], np.ndarray)
+
+            if all([arg0_is_arr, arg1_is_arr, arg2_is_arr]):
+                self._from_arrays(args[0], args[1], args[2])
+
+
+    def _from_arrays(self, x, y, z):
+        """
+        Create VTK rectilinear grid directly from numpy arrays. Each array
+        gives the uniques coordinates of the mesh along each axial direction.
+        To help ensure you are using this correctly, we take the unique values
+        of each argument.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Coordinates of the nodes in x direction.
+
+        y : np.ndarray
+            Coordinates of the nodes in y direction.
+
+        z : np.ndarray
+            Coordinates of the nodes in z direction.
+        """
+        x = np.unique(x.ravel())
+        y = np.unique(y.ravel())
+        z = np.unique(z.ravel())
+        # Set the cell spacings and dimensions of the grid
+        self.SetDimensions(len(x), len(y), len(z))
+        self.SetXCoordinates(numpy_to_vtk(x))
+        self.SetYCoordinates(numpy_to_vtk(y))
+        self.SetZCoordinates(numpy_to_vtk(z))
+
+
+    @property
+    def points(self):
+        """ returns a pointer to the points as a numpy object """
+        x = vtk_to_numpy(self.GetXCoordinates())
+        y = vtk_to_numpy(self.GetYCoordinates())
+        z = vtk_to_numpy(self.GetZCoordinates())
+        xx, yy, zz = np.meshgrid(x,y,z, indexing='ij')
+        return np.c_[xx.ravel(), yy.ravel(), zz.ravel()]
+
+    @points.setter
+    def points(self, points):
+        """ set points without copying """
+        if not isinstance(points, np.ndarray):
+            raise TypeError('Points must be a numpy array')
+        # get the unique coordinates along each axial direction
+        x = np.unique(points[:,0])
+        y = np.unique(points[:,1])
+        z = np.unique(points[:,2])
+        # Set the vtk coordinates
+        self._from_arrays(x, y, z)
+        # TODO: what is this?
+        self._point_ref = points
+
+
+    def _load_file(self, filename):
+        """
+        Load a rectilinear grid from a file.
+
+        The file extension will select the type of reader to use.  A .vtk
+        extension will use the legacy reader, while .vts will select the VTK
+        XML reader.
+
+        Parameters
+        ----------
+        filename : str
+            Filename of grid to be loaded.
+
+        """
+        # check file exists
+        if not os.path.isfile(filename):
+            raise Exception('%s does not exist')
+
+        # Check file extention
+        if '.vtr' in filename:
+            legacy_writer = False
+        elif '.vtk' in filename:
+            legacy_writer = True
+        else:
+            raise Exception(
+                'Extension should be either ".vtr" (xml) or ".vtk" (legacy)')
+
+        # Create reader
+        if legacy_writer:
+            reader = vtk.vtkRectilinearGridReader()
+        else:
+            reader = vtk.vtkXMLRectilinearGridReader()
+
+        # load file to self
+        reader.SetFileName(filename)
+        reader.Update()
+        grid = reader.GetOutput()
+        self.ShallowCopy(grid)
+
+    def save(self, filename, binary=True):
+        """
+        Writes a rectilinear grid to disk.
+
+        Parameters
+        ----------
+        filename : str
+            Filename of grid to be written.  The file extension will select the
+            type of writer to use.  ".vtk" will use the legacy writer, while
+            ".vts" will select the VTK XML writer.
+
+        binary : bool, optional
+            Writes as a binary file by default.  Set to False to write ASCII.
+
+
+        Notes
+        -----
+        Binary files write much faster than ASCII, but binary files written on
+        one system may not be readable on other systems.  Binary can be used
+        only with the legacy writer.
+
+        """
+        # Use legacy writer if vtk is in filename
+        if '.vtk' in filename:
+            writer = vtk.vtkRectilinearGridWriter()
+            legacy = True
+        elif '.vtr' in filename:
+            writer = vtk.vtkXMLRectilinearGridWriter()
+            legacy = False
+        else:
+            raise Exception('Extension should be either ".vtr" (xml) or' +
+                            '".vtk" (legacy)')
+        # Write
+        writer.SetFileName(filename)
+        writer.SetInputData(self)
+        if binary and legacy:
+            writer.SetFileTypeToBinary
+        writer.Write()
+
+    @property
+    def x(self):
+        return vtk_to_numpy(self.GetXCoordinates())
+
+    @property
+    def y(self):
+        return vtk_to_numpy(self.GetYCoordinates())
+
+    @property
+    def z(self):
+        return vtk_to_numpy(self.GetZCoordinates())
+
+    # @property
+    # def quality(self):
+    #     """
+    #     Computes the minimum scaled jacobian of each cell.  Cells that have
+    #     values below 0 are invalid for a finite element analysis.
+    #
+    #     Returns
+    #     -------
+    #     cellquality : np.ndarray
+    #         Minimum scaled jacobian of each cell.  Ranges from -1 to 1.
+    #
+    #     Notes
+    #     -----
+    #     Requires pyansys to be installed.
+    #
+    #     """
+    #     return UnstructuredGrid(self).quality
+
+
+
+
+class UniformGrid(vtkImageData, Grid):
+    """
+    Extends the functionality of a vtk.vtkImageData object
+    Can be initialized in several ways:
+
+    - Create empty grid
+    - Initialize from a vtk.vtkImageData object
+    - Initialize directly from the point arrays
+
+    See ``_from_specs`` in the documentation for more details on initializing
+    from point arrays
+
+    Examples
+    --------
+    >>> grid = UniformGrid()  # Create empty grid
+    >>> grid = UniformGrid(vtkgrid)  # Initialize from a vtk.vtkImageData object
+    >>> dims = (10, 10, 10)
+    >>> grid = vtki.UniformGrid(dims) # Using default spacing and origin
+    >>> spacing = (2, 1, 5)
+    >>> grid = vtki.UniformGrid(dims, spacing) # Usign default origin
+    >>> origin = (10, 35, 50)
+    >>> grid = vtki.UniformGrid(dims, spacing, origin) # Everything is specified
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(UniformGrid, self).__init__()
+
+        if len(args) == 1:
+            if isinstance(args[0], vtk.vtkImageData):
+                self.DeepCopy(args[0])
+            elif isinstance(args[0], str):
+                self._load_file(args[0])
+            else:
+                arg0_is_valid = len(args[0]) == 3
+                self._from_specs(args[0])
+
+        elif len(args) > 1 and len(args) < 4:
+            arg0_is_valid = len(args[0]) == 3
+            arg1_is_valid = False
+            if len(args) > 1:
+                arg1_is_valid = len(args[1]) == 3
+            arg2_is_valid = False
+            if len(args) > 2:
+                arg2_is_valid = len(args[2]) == 3
+
+            if all([arg0_is_valid, arg1_is_valid, arg2_is_valid]):
+                self._from_specs(args[0], args[1], args[2])
+            elif all([arg0_is_valid, arg1_is_valid]):
+                self._from_specs(args[0], args[1])
+
+
+    def _from_specs(self, dims, spacing=(1.0,1.0,1.0), origin=(0.0, 0.0, 0.0)):
+        """
+        Create VTK image data directly from numpy arrays. A uniform grid is
+        defined by the node spacings for each axis (uniform along each
+        individual axis) and the number of nodes on each axis. These are
+        relative to a specified origin (default is ``(0.0, 0.0, 0.0)``).
+
+        Parameters
+        ----------
+        dims : tuple(int)
+            Length 3 tuple of ints specifying how many nodes along each axis
+
+        spacing : tuple(float)
+            Length 3 tuple of floats/ints specifying the node spacings for each axis
+
+        origin : tuple(float)
+            Length 3 tuple of floats/ints specifying minimum value for each axis
+        """
+        xn, yn, zn = dims[0], dims[1], dims[2]
+        xs, ys, zs = spacing[0], spacing[1], spacing[2]
+        xo, yo, zo = origin[0], origin[1], origin[2]
+        self.SetDimensions(xn, yn, zn)
+        self.SetOrigin(xo, yo, zo)
+        self.SetSpacing(xs, ys, zs)
+
+
+    @property
+    def points(self):
+        """ returns a pointer to the points as a numpy object """
+        # Get grid dimensions
+        nx, ny, nz = self.GetDimensions()
+        nx -= 1
+        ny -= 1
+        nz -= 1
+        # get the points and convert to spacings
+        dx, dy, dz = self.GetSpacing()
+        # Now make the cell arrays
+        ox, oy, oz = self.GetOrigin()
+        x = np.cumsum(np.full(nx, dx)) + ox
+        y = np.cumsum(np.full(ny, dy)) + oy
+        z = np.cumsum(np.full(nz, dz)) + oz
+        xx, yy, zz = np.meshgrid(x,y,z, indexing='ij')
+        return np.c_[xx.ravel(), yy.ravel(), zz.ravel()]
+
+    @points.setter
+    def points(self, points):
+        """ set points without copying """
+        if not isinstance(points, np.ndarray):
+            raise TypeError('Points must be a numpy array')
+        # get the unique coordinates along each axial direction
+        x = np.unique(points[:,0])
+        y = np.unique(points[:,1])
+        z = np.unique(points[:,2])
+        nx, ny, nz = len(x), len(y), len(z)
+        # TODO: this needs to be tested (unique might return a tuple)
+        dx, dy, dz = np.unique(np.diff(x)), np.unique(np.diff(y)), np.unique(np.diff(z))
+        ox, oy, oz = np.min(x), np.min(y), np.min(z)
+        # Build the vtk object
+        self._from_specs(self, (nx,ny,nz), (dx,dy,dz), (ox,oy,oz))
+        # TODO: what is this?
+        self._point_ref = points
+
+
+    def _load_file(self, filename):
+        """
+        Load image data from a file.
+
+        The file extension will select the type of reader to use.  A ``.vtk``
+        extension will use the legacy reader, while ``.vti`` will select the VTK
+        XML reader.
+
+        Parameters
+        ----------
+        filename : str
+            Filename of grid to be loaded.
+
+        """
+        # check file exists
+        if not os.path.isfile(filename):
+            raise Exception('%s does not exist')
+
+        # Check file extention
+        if '.vti' in filename:
+            legacy_writer = False
+        elif '.vtk' in filename:
+            legacy_writer = True
+        else:
+            raise Exception(
+                'Extension should be either ".vti" (xml) or ".vtk" (legacy)')
+
+        # Create reader
+        if legacy_writer:
+            reader = vtk.vtkImageDataReader()
+        else:
+            reader = vtk.vtkXMLImageDataReader()
+
+        # load file to self
+        reader.SetFileName(filename)
+        reader.Update()
+        grid = reader.GetOutput()
+        self.ShallowCopy(grid)
+
+    def save(self, filename, binary=True):
+        """
+        Writes image data grid to disk.
+
+        Parameters
+        ----------
+        filename : str
+            Filename of grid to be written.  The file extension will select the
+            type of writer to use.  ".vtk" will use the legacy writer, while
+            ".vti" will select the VTK XML writer.
+
+        binary : bool, optional
+            Writes as a binary file by default.  Set to False to write ASCII.
+
+
+        Notes
+        -----
+        Binary files write much faster than ASCII, but binary files written on
+        one system may not be readable on other systems.  Binary can be used
+        only with the legacy writer.
+
+        """
+        # Use legacy writer if vtk is in filename
+        if '.vtk' in filename:
+            writer = vtk.vtkImageDataWriter()
+            legacy = True
+        elif '.vti' in filename:
+            writer = vtk.vtkXMLImageDataWriter()
+            legacy = False
+        else:
+            raise Exception('Extension should be either ".vti" (xml) or' +
+                            '".vtk" (legacy)')
+        # Write
+        writer.SetFileName(filename)
+        writer.SetInputData(self)
+        if binary and legacy:
+            writer.SetFileTypeToBinary
+        writer.Write()
+
+    @property
+    def x(self):
+        return self.points[:, 0]
+
+    @property
+    def y(self):
+        return self.points[:, 1]
+
+    @property
+    def z(self):
+        return self.points[:, 2]
+
+    # @property
+    # def quality(self):
+    #     """
+    #     Computes the minimum scaled jacobian of each cell.  Cells that have
+    #     values below 0 are invalid for a finite element analysis.
+    #
+    #     Returns
+    #     -------
+    #     cellquality : np.ndarray
+    #         Minimum scaled jacobian of each cell.  Ranges from -1 to 1.
+    #
+    #     Notes
+    #     -----
+    #     Requires pyansys to be installed.
+    #
+    #     """
+    #     return UnstructuredGrid(self).quality

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -848,8 +848,6 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         z = np.unique(points[:,2])
         # Set the vtk coordinates
         self._from_arrays(x, y, z)
-        # TODO: what is this?
-        self._point_ref = points
 
 
     def _load_file(self, filename):
@@ -1074,8 +1072,6 @@ class UniformGrid(vtkImageData, Grid):
         ox, oy, oz = np.min(x), np.min(y), np.min(z)
         # Build the vtk object
         self._from_specs(self, (nx,ny,nz), (dx,dy,dz), (ox,oy,oz))
-        # TODO: what is this?
-        self._point_ref = points
 
 
     def _load_file(self, filename):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -429,7 +429,10 @@ class Plotter(object):
         if scalars is not None:
             # if scalars is a string, then get the first array found with that name
             if isinstance(scalars, str):
+                tit = scalars
                 scalars = get_scalar(mesh, scalars)
+                if stitle is None:
+                    stitle = tit
 
             if not isinstance(scalars, np.ndarray):
                 scalars = np.asarray(scalars)

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -15,7 +15,7 @@ from vtk.util import numpy_support as VN
 
 import numpy as np
 import vtki
-import vtki
+from vtki.utilities import get_scalar, wrap
 import imageio
 
 
@@ -56,7 +56,7 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
 
     full_screen : bool, optional
         Opens window in full screen.  When enabled, ignores window_size.
-        Default False.    
+        Default False.
 
     screenshot : str or bool, optional
         Saves screenshot to file when enabled.  See:
@@ -412,6 +412,13 @@ class Plotter(object):
             mesh = vtki.PolyData(mesh)
             style = 'points'
 
+        try:
+            if mesh._is_vtki:
+                pass
+        except:
+            # Convert the VTK data object to a vtki wrapped object
+            mesh = wrap(mesh)
+
         # set main values
         self.mesh = mesh
         self.mapper = vtk.vtkDataSetMapper()
@@ -420,6 +427,10 @@ class Plotter(object):
 
         # Scalar formatting ===================================================
         if scalars is not None:
+            # if scalars is a string, then get the first array found with that name
+            if isinstance(scalars, str):
+                scalars = get_scalar(mesh, scalars)
+
             if not isinstance(scalars, np.ndarray):
                 scalars = np.asarray(scalars)
 
@@ -970,7 +981,7 @@ class Plotter(object):
         Parameters
         ----------
         lines : np.ndarray or vtki.PolyData
-            Points representing line segments.  For example, two line segments 
+            Points representing line segments.  For example, two line segments
             would be represented as:
 
             np.array([[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0]])
@@ -1220,7 +1231,7 @@ class Plotter(object):
         Parameters
         ----------
         labels : list, optional
-            When set to None, uses existing labels as specified by 
+            When set to None, uses existing labels as specified by
 
             - add_mesh
             - add_lines
@@ -1271,8 +1282,8 @@ class Plotter(object):
         >>> plotter.add_mesh(othermesh, 'k')
         >>> plotter.add_legend(legend_entries)
         >>> plotter.plot()
-        """        
-        legend = vtk.vtkLegendBoxActor()        
+        """
+        legend = vtk.vtkLegendBoxActor()
 
         if labels is None:
             # use existing labels

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -38,6 +38,19 @@ def _raise_not_matching(scalars, mesh):
                     '(%d) ' % mesh.GetNumberOfCells())
 
 
+def get_default_cam_pos(dataset):
+    """Returns the default focal points and viewup. Position is way too
+    subjective and the renderer's reset should just be called.
+    """
+    bounds = dataset.GetBounds()
+    x = (bounds[1] + bounds[0])/2
+    y = (bounds[3] + bounds[2])/2
+    z = (bounds[5] + bounds[4])/2
+    fp = [x, y, z]
+    vup = [0.45, 0.45, 0.75]
+    return [fp, vup]
+
+
 def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
          interactive=True, cpos=None, window_size=DEFAULT_WINDOW_SIZE,
          show_bounds=False, show_axes=True, notebook=False, background=None,
@@ -122,6 +135,8 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
     if show_bounds:
         plotter.add_bounds_axes()
 
+    if cpos is None:
+        cpos = get_default_cam_pos(var_item)
     plotter.camera_position = cpos
     cpos = plotter.plot(window_size=window_size,
                         autoclose=False,
@@ -1195,9 +1210,16 @@ class Plotter(object):
         if cameraloc is None:
             return
 
-        self.camera.SetPosition(cameraloc[0])
-        self.camera.SetFocalPoint(cameraloc[1])
-        self.camera.SetViewUp(cameraloc[2])
+        if len(cameraloc) == 3:
+            # everything is set explicitly
+            self.camera.SetPosition(cameraloc[0])
+            self.camera.SetFocalPoint(cameraloc[1])
+            self.camera.SetViewUp(cameraloc[2])
+        else:
+            # Set the focal point ant view up then reset the position
+            self.camera.SetFocalPoint(cameraloc[0])
+            self.camera.SetViewUp(cameraloc[1])
+            self.renderer.ResetCamera()
 
         # reset clipping range
         self.renderer.ResetCameraClippingRange()

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -229,7 +229,7 @@ class Plotter(object):
     q_pressed = False
     right_timer_id = -1
 
-    def __init__(self, off_screen=False, notebook=False):
+    def __init__(self, off_screen=False, notebook=None):
         """
         Initialize a vtk plotting object
         """
@@ -245,6 +245,8 @@ class Plotter(object):
 
         self._labels = []
 
+        if notebook is None:
+            notebook = type(get_ipython()).__module__.startswith('ipykernel.')
         self.notebook = notebook
         if self.notebook:
             off_screen = True
@@ -1428,10 +1430,13 @@ class Plotter(object):
                 raise Exception('Install iPython to display image in a notebook')
 
             img = self.screenshot()
-            IPython.display.display(PIL.Image.fromarray(img))
+            disp = IPython.display.display(PIL.Image.fromarray(img))
 
         if autoclose:
             self.close()
+
+        if self.notebook:
+            return disp
 
         return cpos
 

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -53,7 +53,7 @@ def get_default_cam_pos(dataset):
 
 def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
          interactive=True, cpos=None, window_size=DEFAULT_WINDOW_SIZE,
-         show_bounds=False, show_axes=True, notebook=False, background=None,
+         show_bounds=False, show_axes=True, notebook=None, background=None,
          text='', **kwargs):
     """
     Convenience plotting function for a vtk or numpy object.
@@ -108,6 +108,10 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
         Returned only when screenshot enabled
 
     """
+    if notebook is None:
+        notebook = type(get_ipython()).__module__.startswith('ipykernel.')
+    if notebook:
+        off_screen = notebook
     plotter = Plotter(off_screen=off_screen)
     if show_axes:
         plotter.add_axes()
@@ -144,9 +148,10 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
                         full_screen=full_screen)
 
     # take screenshot
+    img = plotter.screenshot()
     if screenshot:
         if screenshot == True:
-            img = plotter.screenshot()
+            pass
         else:
             img = plotter.screenshot(screenshot)
 
@@ -158,8 +163,7 @@ def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
             import IPython
         except ImportError:
             raise Exception('Install ipython to display image in a notebook')
-
-        IPython.display.display(PIL.Image.fromarray(img))
+        return IPython.display.display(PIL.Image.fromarray(img))
 
     if screenshot:
         return cpos, img

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -152,8 +152,10 @@ def wrap(vtkdataset):
     """
     wrappers = {
         'vtkUnstructuredGrid' : vtki.UnstructuredGrid,
+        'vtkRectilinearGrid' : vtki.RectilinearGrid,
         'vtkStructuredGrid' : vtki.StructuredGrid,
         'vtkPolyData' : vtki.PolyData,
+        'vtkImageData' : vtki.UniformGrid,
         }
     key = vtkdataset.GetClassName()
     try:


### PR DESCRIPTION
Overall, this pull request is adding wrappers for `vtkImageData` and `vtkRectilinearGrids` as well as  a few features I found useful:

## `vtki.wrap`

A new wrapping method under the `utilities` module. This allows users to quickly wrap any VTK dataset they have to its appropriate `vtki` object:

```py
import vtk, vtki
stuff = vtk.vtkPolyData()
better = vtki.wrap(stuff)
```

## `vtki.Common._repr_html_` and a few other methods

A new way to represent the object in Jupyter notebooks that might be a bit more insightful that printing the class name and memory address. See below:

<img width="633" alt="screen shot 2018-12-18 at 9 54 47 pm" src="https://user-images.githubusercontent.com/22067021/50196026-91fa3f00-030f-11e9-8ce2-50079f85b2f7.png">


## `vtki.get_scalar`

A helper to search both the Point and Cell data for an array by its name. This allows users to now pass an array name to the `plot`/`add_mesh` method so that it will find the Cell or Point data with that name and then color the dataset by that array.

<img width="659" alt="screen shot 2018-12-18 at 9 52 41 pm" src="https://user-images.githubusercontent.com/22067021/50195966-46479580-030f-11e9-8623-b57afe57ec86.png">

<img width="1197" alt="screen shot 2018-12-18 at 9 52 30 pm" src="https://user-images.githubusercontent.com/22067021/50195967-48a9ef80-030f-11e9-848d-218c3a1cedac.png">


## Other updates

- I fixed the ReadTheDocs badge and cleaned up the README

## What's Next?

### Jupyter Plotting

I really, REALLY want to get the plotting code working for interactive plots in Jupyter notebooks. I think I can get some traction on this from both myself and a few other open-source developers using VTK. 

What is needed to implement interactive 3D plots in Jupyter notebooks? Can we just open the rendering window into a frame in the notebook?


### Other Wrappers

I have a branch started for adding a `vtkMultiBlockDataSet` wrapper. This will be necessary for me to use `vtki` with my project [**`PVGeo`**](https://github.com/OpenGeoVis/PVGeo) so hopefully, we can collaborate to make a wrapper for multiblock datasets.

### Wrapping VTK algorithms

I have been thinking about wrapping all of the VTK algorithms/filters into a common API such that users can call the filters/ writers in a more Pythonic manner. **Is this something that might fit into `vtki`?** For example, we could wrap the `vtkThreshold` to go from:

```py
import vtk
alg = vtkThreshold()
alg.SetInputDataObject(pdi)
alg.ThresholdByLower(99.0)
alg.Update()
pdo = alg.GetOutputDataObject(0)
```

to this easier API:

```py
import vtki
pdo = vtki.algs.Threshold(pdi, 99.0, option='lower')
```

## Why am I doing this?

`vtki` is AWESOME! Having these wrappers make using the VTK data objects so, so, so much easier in Python. The rendering code and plotting routines are also great and I would like to leverage these for a library I am building that is basically a bunch of VTK algorithms designed for geoscience datasets ([**`PVGeo`**](https://github.com/OpenGeoVis/PVGeo)). 