### PR TITLE
Overhaul to the scalar bar management and some syntax changes

### DIFF
--- a/notebooks/Scalar-Bar-Preservation.ipynb
+++ b/notebooks/Scalar-Bar-Preservation.ipynb
@@ -1,0 +1,247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scalar Bar Preservation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import vtki\n",
+    "from vtki import examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tr><th>Information</th><th>Data Arrays</th></tr><tr><td>\n",
+       "<table>\n",
+       "<tr><th>vtkImageData</th><th>Values</th></tr>\n",
+       "<tr><td>N Cells</td><td>729</td></tr>\n",
+       "<tr><td>N Points</td><td>1000</td></tr>\n",
+       "<tr><td>X Bounds</td><td>0.000, 9.000</td></tr>\n",
+       "<tr><td>Y Bounds</td><td>0.000, 9.000</td></tr>\n",
+       "<tr><td>Z Bounds</td><td>0.000, 9.000</td></tr>\n",
+       "</table>\n",
+       "\n",
+       "</td><td>\n",
+       "<table>\n",
+       "<tr><th>Name</th><th>Field</th><th>Type</th><th>Min</th><th>Max</th></tr>\n",
+       "<tr><td><b>Spatial Point Data</b></td><td>Points</td><td>float64</td><td>0.000e+00</td><td>7.290e+02</td></tr>\n",
+       "<tr><td>Spatial Cell Data</td><td>Cells</td><td>float64</td><td>0.000e+00</td><td>5.120e+02</td></tr>\n",
+       "</table>\n",
+       "\n",
+       "</td></tr> </table>"
+      ],
+      "text/plain": [
+       "(UniformGrid)0x1192a3348"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid = examples.load_uniform()\n",
+    "#grid.set_active_scalar('Spatial Point Data')\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the rendering window\n",
+    "plotter = vtki.BackgroundPlotter() #Plotter(notebook=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add some features\n",
+    "ca = plotter.add_mesh(grid.clip())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(vtkRenderingAnnotationPython.vtkCubeAxesActor)0x11faae948"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "oa = plotter.add_mesh(grid.outline())\n",
+    "plotter.add_bounds_axes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "slot 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "plotter.remove_actor(sa)\n",
+    "sa = plotter.add_mesh(grid.threshold(250, invert=True), \n",
+    "                      scalars='Spatial Cell Data', \n",
+    "                      showedges=False,\n",
+    "                      colormap='Greys',\n",
+    "                      opacity=0.6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "slot 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add some contours\n",
+    "cta = plotter.add_mesh(grid.contour(), showedges=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Update the clip \n",
+    "plotter.remove_actor(ca)\n",
+    "ca = plotter.add_mesh(grid.clip(origin=(6,5,5), normal='-x'), \n",
+    "                      opacity=0.5, showedges=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "plotter._scalar_bar_mappers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.remove_actor(ca)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.remove_actor(cta)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.remove_actor(sa)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.clear()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:ogv]",
+   "language": "python",
+   "name": "conda-env-ogv-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -54,10 +54,9 @@ def test_plot_invalid_style():
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")
-def test_plot_invalid_bounds_axes():
-    with pytest.raises(Exception):
-        plotter = vtki.Plotter()
-        plotter.add_bounds_axes()
+def test_plot_bounds_axes_with_no_data():
+    plotter = vtki.Plotter()
+    plotter.add_bounds_axes()
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1574,7 +1574,7 @@ class BasePlotter(object):
             input grid by default.
 
         callback : function, optional
-            When input, calls this function after a selection is made.  
+            When input, calls this function after a selection is made.
             The picked_cells are input as the first parameter to this function.
 
         """
@@ -1676,7 +1676,8 @@ class Plotter(BasePlotter):
         self.camera_set = False
         self.first_time = True
 
-    def plot(self, title=None, window_size=plotParams['window_size'],
+
+    def show(self, title=None, window_size=plotParams['window_size'],
              interactive=True, autoclose=True, interactive_update=False,
              full_screen=False):
         """
@@ -1761,6 +1762,10 @@ class Plotter(BasePlotter):
             return disp
 
         return cpos
+
+    def plot(self, **kwargs):
+        """ Present for backwards compatibility. Use `show()` instead """
+        return self.show(**kwargs)
 
     def render(self):
         """ renders main window """

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -43,7 +43,13 @@ plotParams = {
         'label_size' : None,
         'color' : [1, 1, 1],
     },
-    'colormap' : 'jet'
+    'colormap' : 'jet',
+    'colorbar' : {
+        'width' : 0.60,
+        'height' : 0.05,
+        'position_x' : 0.35,
+        'position_y' : 0.02,
+    },
 }
 
 def set_plot_theme(theme):
@@ -70,6 +76,21 @@ def _raise_not_matching(scalars, mesh):
                     '(%d) ' % mesh.GetNumberOfPoints() +
                     'or the number of cells ' +
                     '(%d) ' % mesh.GetNumberOfCells())
+
+def _remove_mapper_from_plotter(plotter, actor):
+    """removes this actor's mapper from the given plotter's _scalar_bar_mappers"""
+    mapper = actor.GetMapper()
+    for name in list(plotter._scalar_bar_mappers.keys()):
+        try:
+            plotter._scalar_bar_mappers[name].remove(mapper)
+        except ValueError:
+            pass
+        if len(plotter._scalar_bar_mappers[name]) < 1:
+            plotter._scalar_bar_mappers.pop(name)
+            plotter._scalar_bar_ranges.pop(name)
+            plotter.remove_actor(plotter._scalar_bar_actors.pop(name), remove_mapper=False)
+            plotter._scalar_bar_slots.insert(0, plotter._scalar_bar_slot_lookup.pop(name))
+    return
 
 
 def plot(var_item, off_screen=False, full_screen=False, screenshot=None,
@@ -245,6 +266,15 @@ class BasePlotter(object):
 
     def __init__(self):
         self.renderer = vtk.vtkRenderer()
+
+        # This is a private variable to keep track of how many colorbars exist
+        # This allows us to keep adding colorbars without overlapping
+        self._scalar_bar_slots = list(range(10))
+        self._scalar_bar_slot_lookup = {}
+        # This keeps track of scalar names already plotted and their ranges
+        self._scalar_bar_ranges = {}
+        self._scalar_bar_mappers = {}
+        self._scalar_bar_actors = {}
 
     def clear(self):
         """ Clears plot by removing all actors and properties """
@@ -524,7 +554,7 @@ class BasePlotter(object):
                 scalars = get_scalar(mesh, scalars)
                 if stitle is None:
                     stitle = title
-                append_scalars = False
+                #append_scalars = False
 
             if not isinstance(scalars, np.ndarray):
                 scalars = np.asarray(scalars)
@@ -546,6 +576,8 @@ class BasePlotter(object):
                 self.mesh._add_cell_scalar(scalars, title, append_scalars)
                 self.mapper.SetScalarModeToUseCellData()
                 self.mapper.GetLookupTable().SetNumberOfTableValues(ncolors)
+                if interpolatebeforemap:
+                    self.mapper.InterpolateScalarsBeforeMappingOn()
             else:
                 _raise_not_matching(scalars, mesh)
 
@@ -667,7 +699,7 @@ class BasePlotter(object):
     def camera(self):
         return self.renderer.GetActiveCamera()
 
-    def remove_actor(self, actor):
+    def remove_actor(self, actor, remove_mapper=True):
         """
         Removes an actor from the Plotter.
 
@@ -676,6 +708,9 @@ class BasePlotter(object):
         actor : vtk.vtkActor
             Actor that has previously added to the Plotter.
         """
+        # First remove this actor's mapper from _scalar_bar_mappers
+        if remove_mapper:
+            _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)
 
     def add_axes_at_origin(self):
@@ -860,7 +895,8 @@ class BasePlotter(object):
 
     def add_scalar_bar(self, title=None, nlabels=5, italic=False, bold=True,
                        title_fontsize=None, label_fontsize=None, color=None,
-                       font_family=None, shadow=False, mapper=None):
+                       font_family=None, shadow=False, mapper=None,
+                       width=None, height=None, position_x=None, position_y=None):
         """
         Creates scalar bar using the ranges as set by the last input mesh.
 
@@ -899,6 +935,20 @@ class BasePlotter(object):
         shadow : bool, optional
             Adds a black shadow to the text.  Defaults to False
 
+        width : float, optional
+            The percentage (0 to 1) width of the window fo the colorbar
+
+        height : float, optional
+            The percentage (0 to 1) height of the window for the colorbar
+
+        position_x : float, optional
+            The percentage (0 to 1) along the winow's horizontal direction to
+            place the bottom left corner of the colorbar
+
+        position_y : float, optional
+            The percentage (0 to 1) along the winow's vertical direction to
+            place the bottom left corner of the colorbar
+
         Notes
         -----
         Setting title_fontsize, or label_fontsize disables automatic font
@@ -914,6 +964,26 @@ class BasePlotter(object):
             title_fontsize = plotParams['font']['title_size']
         if color is None:
             color = plotParams['font']['color']
+        # Automatically choose size if not specified
+        if width is None:
+            width = plotParams['colorbar']['width']
+        if height is None:
+            height = plotParams['colorbar']['height']
+        # Automatically choose location if not specified
+        if position_x is None or position_y is None:
+            try:
+                slot = self._scalar_bar_slots.pop(0)
+            except:
+                raise RuntimeError('Maximum number of color bars reached.')
+            if position_x is None:
+                position_x = plotParams['colorbar']['position_x']
+            if position_y is None:
+                position_y = plotParams['colorbar']['position_y'] + slot * height
+        # Adjust to make sure on the screen
+        if position_x + width > 1:
+            position_x -= width
+        if position_y + height > 1:
+            position_y -= height
 
         # check if maper exists
         if mapper is None:
@@ -921,6 +991,30 @@ class BasePlotter(object):
                 raise Exception('Mapper does not exist.  ' +
                                 'Add a mesh with scalars first.')
             mapper = self.mapper
+
+        if title:
+            # Check that this data hasn't already been plotted
+            if title in list(self._scalar_bar_ranges.keys()):
+                rng = list(self._scalar_bar_ranges[title])
+                newrng = mapper.GetScalarRange()
+                oldmappers = self._scalar_bar_mappers[title]
+                # get max for range and reset everything
+                if newrng[0] < rng[0]:
+                    rng[0] = newrng[0]
+                if newrng[1] > rng[1]:
+                    rng[1] = newrng[1]
+                for m in oldmappers:
+                    m.SetScalarRange(rng[0], rng[1])
+                mapper.SetScalarRange(rng[0], rng[1])
+                self._scalar_bar_mappers[title].append(mapper)
+                self._scalar_bar_ranges[title] = rng
+                # Color bar already present and ready to be used so returning
+                return
+            else:
+                rng = mapper.GetScalarRange()
+                self._scalar_bar_ranges[title] = rng
+                self._scalar_bar_mappers[title] = [mapper]
+                self._scalar_bar_slot_lookup[title] = slot
 
         # parse color
         color = parse_color(color)
@@ -931,9 +1025,10 @@ class BasePlotter(object):
         self.scalar_bar.SetNumberOfLabels(nlabels)
 
         # edit the size of the colorbar
-        self.scalar_bar.SetHeight(0.9)
-        self.scalar_bar.SetWidth(0.05)
-        self.scalar_bar.SetPosition(0.90, 0.02)
+        self.scalar_bar.SetHeight(height)
+        self.scalar_bar.SetWidth(width)
+        self.scalar_bar.SetPosition(position_x, position_y)
+        self.scalar_bar.SetOrientationToHorizontal()
 
         if label_fontsize is None or title_fontsize is None:
             self.scalar_bar.UnconstrainedFontSizeOn()
@@ -955,6 +1050,8 @@ class BasePlotter(object):
             self.scalar_bar.SetTitle(title)
             title_text = self.scalar_bar.GetTitleTextProperty()
 
+            title_text.SetJustificationToCentered()
+
             title_text.SetItalic(italic)
             title_text.SetBold(bold)
             title_text.SetShadow(shadow)
@@ -966,6 +1063,8 @@ class BasePlotter(object):
 
             # set color
             title_text.SetColor(color)
+
+            self._scalar_bar_actors[title] = self.scalar_bar
 
         self.add_actor(self.scalar_bar)
 
@@ -1038,6 +1137,12 @@ class BasePlotter(object):
         # must close out axes marker
         if hasattr(self, 'axes_widget'):
             del self.axes_widget
+
+        # reset scalar bar stuff
+        self._scalar_bar_slots = list(range(10))
+        self._scalar_bar_slot_lookup = {}
+        self._scalar_bar_ranges = {}
+        self._scalar_bar_mappers = {}
 
         if hasattr(self, 'ren_win'):
             self.ren_win.Finalize()
@@ -1552,8 +1657,11 @@ class BasePlotter(object):
             self.remove_actor(self.legend)
             self._render()
 
-    def remove_actor(self, actor):
+    def remove_actor(self, actor, remove_mapper=True):
         """ removes an actor """
+        # First remove this actor's mapper from _scalar_bar_mappers
+        if remove_mapper:
+            _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)
         self._render()
 

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -80,7 +80,10 @@ def _raise_not_matching(scalars, mesh):
 
 def _remove_mapper_from_plotter(plotter, actor):
     """removes this actor's mapper from the given plotter's _scalar_bar_mappers"""
-    mapper = actor.GetMapper()
+    try:
+        mapper = actor.GetMapper()
+    except AttributeError:
+        return
     for name in list(plotter._scalar_bar_mappers.keys()):
         try:
             plotter._scalar_bar_mappers[name].remove(mapper)
@@ -89,7 +92,7 @@ def _remove_mapper_from_plotter(plotter, actor):
         if len(plotter._scalar_bar_mappers[name]) < 1:
             plotter._scalar_bar_mappers.pop(name)
             plotter._scalar_bar_ranges.pop(name)
-            plotter.remove_actor(plotter._scalar_bar_actors.pop(name), remove_mapper=False)
+            plotter.remove_actor(plotter._scalar_bar_actors.pop(name))
             plotter._scalar_bar_slots.add(plotter._scalar_bar_slot_lookup.pop(name))
     return
 
@@ -705,7 +708,7 @@ class BasePlotter(object):
     def camera(self):
         return self.renderer.GetActiveCamera()
 
-    def remove_actor(self, actor, remove_mapper=True):
+    def remove_actor(self, actor):
         """
         Removes an actor from the Plotter.
 
@@ -715,8 +718,7 @@ class BasePlotter(object):
             Actor that has previously added to the Plotter.
         """
         # First remove this actor's mapper from _scalar_bar_mappers
-        if remove_mapper:
-            _remove_mapper_from_plotter(self, actor)
+        _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)
 
     def add_axes_at_origin(self):
@@ -1666,11 +1668,10 @@ class BasePlotter(object):
             self.remove_actor(self.legend)
             self._render()
 
-    def remove_actor(self, actor, remove_mapper=True):
+    def remove_actor(self, actor):
         """ removes an actor """
         # First remove this actor's mapper from _scalar_bar_mappers
-        if remove_mapper:
-            _remove_mapper_from_plotter(self, actor)
+        _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)
         self._render()
 

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -777,11 +777,9 @@ class BasePlotter(object):
         if fontsize is None:
             fontsize = plotParams['font']['size']
 
-        # Use last input mesh if availble
+        # Use the bounds of all data in the rendering window
         if not mesh and not bounds:
-            if not hasattr(self, 'mesh'):
-                raise Exception('Specify bounds or first input a mesh')
-            mesh = self.mesh
+            bounds = self.bounds
 
         # create actor
         cubeAxesActor = vtk.vtkCubeAxesActor()
@@ -790,7 +788,7 @@ class BasePlotter(object):
         # set bounds
         if not bounds:
             bounds = mesh.GetBounds()
-        cubeAxesActor.SetBounds(mesh.GetBounds())
+        cubeAxesActor.SetBounds(bounds)
 
         # show or hide axes
         cubeAxesActor.SetXAxisVisibility(show_xaxis)

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -19,6 +19,7 @@ from vtki.container import MultiBlock
 import imageio
 
 
+MAX_N_COLOR_BARS = 10
 PV_BACKGROUND = [82/255., 87/255., 110/255.]
 FONT_KEYS = {'arial': vtk.VTK_ARIAL,
              'courier': vtk.VTK_COURIER,
@@ -269,7 +270,7 @@ class BasePlotter(object):
 
         # This is a private variable to keep track of how many colorbars exist
         # This allows us to keep adding colorbars without overlapping
-        self._scalar_bar_slots = list(range(10))
+        self._scalar_bar_slots = list(range(MAX_N_COLOR_BARS))
         self._scalar_bar_slot_lookup = {}
         # This keeps track of scalar names already plotted and their ranges
         self._scalar_bar_ranges = {}
@@ -1139,7 +1140,7 @@ class BasePlotter(object):
             del self.axes_widget
 
         # reset scalar bar stuff
-        self._scalar_bar_slots = list(range(10))
+        self._scalar_bar_slots = list(range(MAX_N_COLOR_BARS))
         self._scalar_bar_slot_lookup = {}
         self._scalar_bar_ranges = {}
         self._scalar_bar_mappers = {}


### PR DESCRIPTION
- I refactored `Plotter.plot()` -> `Plotter.show()` to be consistent with `qt_plotting` and `matplotlib` but `Plotter.plot()` is still available for backwards compatibility (it just forwards to `Plotter.show()` now)

- Updated the default behavior of `Plotter.add_bounds_axes()` to add bounds that surround all datasets in the render window.

- A major overhaul to how scalar bars are added and managed so that repeat scalar bars are not added and so they do not overlap.
    - Set a max limit of 10 color bars
    - Change orientation to horizontal and they iteratively stack on top of each other
    - Added `Scalar Bar Preservation` Notebook that helps demo this
    - See gif below to see how the scalar bar is updated when another data set colored by an array with the same title is added.

![ezgif com-video-to-gif-5](https://user-images.githubusercontent.com/22067021/51011391-9c29ea80-1515-11e9-8b61-9d37316593e0.gif)

