### PR TITLE
Feat/bounds: Updates to the bounds_axes

### DIFF
--- a/vtki/ipy_tools.py
+++ b/vtki/ipy_tools.py
@@ -93,7 +93,7 @@ class InteractiveTool(object):
             old = self.plotParams['scalars']
             self.plotParams['scalars'] = scalars
             if old != scalars:
-                self.plotter.remove_actor(self._data_to_update)
+                self.plotter.remove_actor(self._data_to_update, resetcam=False)
                 self._need_to_update = True
         if hasattr(self, 'valid_range'):
             self.plotParams['rng'] = self.valid_range
@@ -148,7 +148,7 @@ class OrthogonalSlicer(InteractiveTool):
         axes = ['x', 'y', 'z']
 
         def _update_slice(index, x, y, z):
-            self.plotter.remove_actor(self._data_to_update[index])
+            self.plotter.remove_actor(self._data_to_update[index], resetcam=False)
             self.output_dataset[index] = self.input_dataset.slice(normal=axes[index], origin=[x,y,z])
             self._data_to_update[index] = self.plotter.add_mesh(self.output_dataset[index],
                     showedges=False, resetcam=False, **self.plotParams)
@@ -243,7 +243,7 @@ class ManySlicesAlongAxis(InteractiveTool):
             if n >= nsl.max:
                 nsl.max *= 2
             self._update_plotting_params(**kwargs)
-            self.plotter.remove_actor(self._data_to_update)
+            self.plotter.remove_actor(self._data_to_update, resetcam=False)
             self.output_dataset = self.input_dataset.slice_along_axis(n=n, axis=axis, tol=tol)
             self._data_to_update = self.plotter.add_mesh(self.output_dataset,
                 showedges=False, resetcam=False, **self.plotParams)
@@ -310,12 +310,15 @@ class Threshold(InteractiveTool):
             maxsl.max = self.valid_range[1]
 
             # Run the threshold
-            self.output_dataset = self.input_dataset.threshold([dmin, dmax], scalars=scalars, continuous=continuous, preference=preference, invert=invert)
+            self.output_dataset = self.input_dataset.threshold([dmin, dmax],
+                    scalars=scalars, continuous=continuous, preference=preference,
+                    invert=invert)
 
             # Update the plotter
             self._update_plotting_params(**kwargs)
-            self.plotter.remove_actor(self._data_to_update)
-            self._data_to_update = self.plotter.add_mesh(self.output_dataset, **self.plotParams)
+            self.plotter.remove_actor(self._data_to_update, resetcam=False)
+            self._data_to_update = self.plotter.add_mesh(self.output_dataset,
+                    resetcam=False, **self.plotParams)
             self._need_to_update = False
 
         # Create/display the widgets

--- a/vtki/ipy_tools.py
+++ b/vtki/ipy_tools.py
@@ -11,6 +11,7 @@ except:
     pass
 
 import collections
+import numpy as np
 
 import vtk
 
@@ -304,6 +305,13 @@ class Threshold(InteractiveTool):
 
             # Update the sliders if scalar is changed
             self.valid_range = self.input_dataset.get_data_range(arr=scalars, preference=preference)
+            # First change the range to infinite so no errors are thrown when
+            # changing ranges
+            minsl.min = -np.inf
+            minsl.max = np.inf
+            maxsl.min = -np.inf
+            maxsl.max = np.inf
+            # Upsate to the new range
             minsl.min = self.valid_range[0]
             minsl.max = self.valid_range[1]
             maxsl.min = self.valid_range[0]
@@ -321,8 +329,17 @@ class Threshold(InteractiveTool):
                     resetcam=False, **self.plotParams)
             self._need_to_update = False
 
+
+        # Only give scalar options that have a varying range
+        names = []
+        for name in self.input_dataset.scalar_names:
+            arr = self.input_dataset.get_scalar(name)
+            rng = self.input_dataset.get_data_range(name)
+            if arr is not None and arr.size > 0 and (rng[1]-rng[0] > 0.0):
+                names.append(name)
+
         # Create/display the widgets
         interact(update, dmin=minsl, dmax=maxsl,
-                 scalars=self.input_dataset.scalar_names,
+                 scalars=names,
                  invert=defaultParams.get('invert', False),
                  continuous=False)

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -283,7 +283,7 @@ class BasePlotter(object):
         self.camera_set = False
         self.first_time = True
         # Keep track of the scale
-        self.scale = [1.0, 1.0, 2.0] # TODO
+        self.scale = [1.0, 1.0, 1.0]
 
 
     def update_bounds_axes(self):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -765,6 +765,8 @@ class BasePlotter(object):
             return
         if actor is None:
             return
+        if isinstance(actor, int):
+            actor = self._actors[actor]
         # First remove this actor's mapper from _scalar_bar_mappers
         _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -770,7 +770,11 @@ class BasePlotter(object):
         # First remove this actor's mapper from _scalar_bar_mappers
         _remove_mapper_from_plotter(self, actor)
         self.renderer.RemoveActor(actor)
-        self._actors.remove(actor)
+        try:
+            self._actors.remove(actor)
+        except ValueError:
+            # Hm, this sometimes happens. Might need a better solution
+            pass
         self.update_bounds_axes()
         if resetcam:
             self.reset_camera()

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1695,7 +1695,7 @@ class BasePlotter(object):
 
     def reset_camera(self):
         """
-        Rest camera so it slides along the vector defined from camera
+        Reset camera so it slides along the vector defined from camera
         position to focal point until all of the actors can be seen.
         """
         self.renderer.ResetCamera()

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -788,6 +788,7 @@ class BasePlotter(object):
         """
         self.marker_actor = vtk.vtkAxesActor()
         self.renderer.AddActor(self.marker_actor)
+        self._actors.append(self.marker_actor)
         return self.marker_actor
 
     def add_bounds_axes(self, mesh=None, bounds=None, show_xaxis=True,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -735,7 +735,9 @@ class BasePlotter(object):
         self.renderer.AddActor(actor)
         self._actors.append(actor)
 
-        if resetcam or not self.camera_set:
+        if resetcam:
+            self.reset_camera()
+        elif not self.camera_set and resetcam is None:
             self.reset_camera()
         else:
             self._render()
@@ -748,7 +750,7 @@ class BasePlotter(object):
     def camera(self):
         return self.renderer.GetActiveCamera()
 
-    def remove_actor(self, actor, resetcam=False):
+    def remove_actor(self, actor, resetcam=None):
         """
         Removes an actor from the Plotter.
 
@@ -768,7 +770,9 @@ class BasePlotter(object):
         self.renderer.RemoveActor(actor)
         self._actors.remove(actor)
         self.update_bounds_axes()
-        if resetcam or not self.camera_set:
+        if resetcam:
+            self.reset_camera()
+        elif not self.camera_set and resetcam is None:
             self.reset_camera()
         else:
             self._render()

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1709,17 +1709,6 @@ class BasePlotter(object):
             self.remove_actor(self.legend)
             self._render()
 
-    def remove_actor(self, actor):
-        """ removes an actor """
-        if isinstance(actor, collections.Iterable):
-            for a in actor:
-                self.remove_actor(a)
-            return
-        # First remove this actor's mapper from _scalar_bar_mappers
-        _remove_mapper_from_plotter(self, actor)
-        self.renderer.RemoveActor(actor)
-        self._render()
-
     def enable_cell_picking(self, mesh=None, callback=None):
         """
         Enables picking of cells.  Press r to enable retangle based

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1821,10 +1821,6 @@ class Plotter(BasePlotter):
         if hasattr(self, 'iren'):
             self.iren.AddObserver(vtk.vtkCommand.TimerEvent, onTimer)
 
-        # track if the camera has been setup
-        self.camera_set = False
-        self.first_time = True
-
 
     def show(self, title=None, window_size=None, interactive=True,
              autoclose=True, interactive_update=False, full_screen=False):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1723,6 +1723,15 @@ class BasePlotter(object):
         self.renderer.ResetCamera()
         self._render()
 
+    def isometric_view(self):
+        """
+        Resets the camera to a default isometric view showing all daa actros in
+        the scene.
+        """
+        self.camera_position = self.get_default_cam_pos()
+        self.camera_set = False
+        return self.reset_camera()
+
     def set_background(self, color):
         """
         Sets background color

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -964,6 +964,16 @@ class BasePlotter(object):
         self.cubeAxesActor = cubeAxesActor
         return cubeAxesActor
 
+    def set_scale(self, xscale=1.0, yscale=1.0, zscale=1.0):
+        """Scale all the datasets in the scene.
+        Scaling in performed independently on the X, Y and Z axis.
+        A scale of zero is illegal and will be replaced with one.
+        """
+        for actor in self._actors:
+            actor.SetScale(xscale, yscale, zscale)
+        self.update_bounds_axes()
+        self._render()
+
     def add_scalar_bar(self, title=None, nlabels=5, italic=False, bold=True,
                        title_fontsize=None, label_fontsize=None, color=None,
                        font_family=None, shadow=False, mapper=None,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -736,7 +736,8 @@ class BasePlotter(object):
             actor = uinput
 
         # Make sure scale is consistent with rest of scene
-        actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
+        if hasattr(actor, 'SetScale'):
+            actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
 
         self.renderer.AddActor(actor)
         self._actors.append(actor)
@@ -978,7 +979,8 @@ class BasePlotter(object):
         """
         self.scale = [xscale, yscale, zscale]
         for actor in self._actors:
-            actor.SetScale(xscale, yscale, zscale)
+            if hasattr(actor, 'SetScale'):
+                actor.SetScale(xscale, yscale, zscale)
         self.update_bounds_axes()
         self._render()
 

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -282,6 +282,8 @@ class BasePlotter(object):
         # track if the camera has been setup
         self.camera_set = False
         self.first_time = True
+        # Keep track of the scale
+        self.scale = [1.0, 1.0, 2.0] # TODO
 
 
     def update_bounds_axes(self):
@@ -732,6 +734,10 @@ class BasePlotter(object):
             actor.SetMapper(uinput)
         else:
             actor = uinput
+
+        # Make sure scale is consistent with rest of scene
+        actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
+
         self.renderer.AddActor(actor)
         self._actors.append(actor)
 
@@ -890,6 +896,7 @@ class BasePlotter(object):
         # create actor
         cubeAxesActor = vtk.vtkCubeAxesActor()
         cubeAxesActor.SetUse2DMode(False)
+        cubeAxesActor.SetScale(self.scale[0], self.scale[1], self.scale[2])
 
         # set bounds
         if not bounds:
@@ -969,6 +976,7 @@ class BasePlotter(object):
         Scaling in performed independently on the X, Y and Z axis.
         A scale of zero is illegal and will be replaced with one.
         """
+        self.scale = [xscale, yscale, zscale]
         for actor in self._actors:
             actor.SetScale(xscale, yscale, zscale)
         self.update_bounds_axes()


### PR DESCRIPTION
This adds the ability for the bounds axes to automatically update to the full extent of the rendering scene. For example, you can add a dataset, add some bounds, then add another dataset with larger bounds and on the next render call, the bounds axes will be updated to the new larger extent.

I have also included a bit that will reset the camera when adding/removing actors unless the camera position has been set or `add_mesh`/`remove_actor` are passed `resetcam=False`. This allows for some nifty interactive plotting where you can add a dataset and the render view will adjust automatically to account for the new information:

![ezgif com-video-to-gif-8](https://user-images.githubusercontent.com/22067021/51096998-080e8c00-177e-11e9-8476-7fd080ca7350.gif)

*There are a few bug fixes for the axes bounds in here.*

This addresses #39