### PR TITLE
Live app icon for BackgroundPlotter

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1293,6 +1293,8 @@ class BasePlotter(object):
     @property
     def image(self):
         """ Returns an image array of current render window """
+        if not hasattr(self, 'ifilter'):
+            self.start_image_filter()
         # Update filter and grab pixels
         self.ifilter.Modified()
         self.ifilter.Update()
@@ -1513,6 +1515,8 @@ class BasePlotter(object):
         >>> plotter.add_mesh(sphere)
         >>> plotter.screenshot('screenshot.png')
         """
+        if not hasattr(self, 'ifilter'):
+            self.start_image_filter()
         # configure image filter
         if transparent_background:
             self.ifilter.SetInputBufferTypeToRGBA()
@@ -1520,7 +1524,11 @@ class BasePlotter(object):
             self.ifilter.SetInputBufferTypeToRGB()
 
         # this needs to be called twice for some reason,  debug later
-        self.render()
+        if isinstance(self, Plotter):
+            # TODO: we need a consistent rendering function
+            self.render()
+        else:
+            self._render()
         img = self.image
         img = self.image
 
@@ -1825,8 +1833,6 @@ class Plotter(BasePlotter):
 
         # Set background
         self.set_background(plotParams['background'])
-
-        self.start_image_filter()
 
         # add timer event if interactive render exists
         if hasattr(self, 'iren'):

--- a/vtki/qt_plotting.py
+++ b/vtki/qt_plotting.py
@@ -179,8 +179,7 @@ class BackgroundPlotter(QtInteractor):
         return actor, prop
 
     def update_app_icon(self):
-        """Update the app icon if it has been at least one second and the user
-        is not trying to resize the window.
+        """Update the app icon if the user is not trying to resize the window.
         """
         cur_time = time.time()
         if self._last_window_size != self.window_size:


### PR DESCRIPTION
This adds a live app icon to the `BackgroundPlotter` to go from this non-descriptive icon:

<img width="261" alt="screen shot 2019-01-14 at 11 03 47 pm" src="https://user-images.githubusercontent.com/22067021/51161740-dd413800-1850-11e9-94a7-ffc1689c6c39.png">

To this informative icon:

![ezgif com-video-to-gif-9](https://user-images.githubusercontent.com/22067021/51161857-49bc3700-1851-11e9-8e33-62f53a92777f.gif)


**Technical Notes**

The app icon gets updated every 5 seconds after the camera position is changed to remain lightweight yet be semi-live.

