### PR TITLE
Develop: bind the plotting method

### DIFF
--- a/vtki/common.py
+++ b/vtki/common.py
@@ -15,6 +15,7 @@ log.setLevel('CRITICAL')
 import vtki
 from vtki.utilities import get_scalar, POINT_DATA_FIELD, CELL_DATA_FIELD
 from vtki import DataSetFilters
+from vtki import plot
 
 
 
@@ -23,6 +24,9 @@ class Common(DataSetFilters):
 
     def __init__(self, *args, **kwargs):
         self.references = []
+
+    # Simply bind vtki.plotting.plot to the object
+    plot = plot
 
     @property
     def active_scalar_info(self):
@@ -169,93 +173,6 @@ class Common(DataSetFilters):
             self.GetPointData().SetActiveScalars(name)
             self._active_scalar_info = [POINT_DATA_FIELD, name]
 
-    def plot(self, **args):
-        """
-        Adds a vtk unstructured, structured, or polymesh to the plotting object
-
-        Parameters
-        ----------
-        mesh : vtk unstructured, structured, or polymesh
-            A vtk unstructured, structured, or polymesh to plot.
-
-        color : string or 3 item list, optional, defaults to white
-            Either a string, rgb list, or hex color string.  For example:
-                color='white'
-                color='w'
-                color=[1, 1, 1]
-                color='#FFFFFF'
-
-            Color will be overridden when scalars are input.
-
-        style : string, optional
-            Visualization style of the vtk mesh.  One for the following:
-                style='surface'
-                style='wireframe'
-                style='points'
-
-            Defaults to 'surface'
-
-        scalars : numpy array, optional
-            Scalars used to "color" the mesh.  Accepts an array equal to the
-            number of cells or the number of points in the mesh.  Array should
-            be sized as a single vector.
-
-        rng : 2 item list, optional
-            Range of mapper for scalars.  Defaults to minimum and maximum of
-            scalars array.  Example: [-1, 2]
-
-        stitle : string, optional
-            Scalar title.  By default there is no scalar legend bar.  Setting
-            this creates the legend bar and adds a title to it.  To create a
-            bar with no title, use an empty string (i.e. '').
-
-        showedges : bool, optional
-            Shows the edges of a mesh.  Does not apply to a wireframe
-            representation.
-
-        psize : float, optional
-            Point size.  Applicable when style='points'.  Default 5.0
-
-        opacity : float, optional
-            Opacity of mesh.  Should be between 0 and 1.  Default 1.0
-
-        linethick : float, optional
-            Thickness of lines.  Only valid for wireframe and surface
-            representations.  Default None.
-
-        flipscalars : bool, optional
-            Flip scalar display approach.  Default is red is minimum and blue
-            is maximum.
-
-        lighting : bool, optional
-            Enable or disable Z direction lighting.  True by default.
-
-        ncolors : int, optional
-            Number of colors to use when displaying scalars.
-
-        interpolatebeforemap : bool, default False
-            Enabling makes for a smoother scalar display.  Default False
-
-        screenshot : str, default None
-            Takes a screenshot when window is closed when a filename is
-            entered as this parameter.
-
-        full_screen : bool, optional
-            Opens window in full screen.  When enabled, ignores window_size.
-            Default False.
-
-        Returns
-        -------
-        cpos : list
-            Camera position, focal point, and view up.
-
-        Examples
-        --------
-        >>> # take screenshot without opening window
-        >>> mesh.plot(off_screen=True, screenshot='mesh_picture.png')
-
-        """
-        return vtki.plot(self, **args)
 
     def points_to_double(self):
         """ Makes points double precision """

--- a/vtki/container.py
+++ b/vtki/container.py
@@ -14,6 +14,7 @@ log.setLevel('CRITICAL')
 
 import vtki
 from vtki.utilities import wrap, is_vtki_obj, get_scalar
+from vtki import plot
 
 
 class MultiBlock(vtkMultiBlockDataSet):
@@ -34,6 +35,9 @@ class MultiBlock(vtkMultiBlockDataSet):
                     self.DeepCopy(args[0])
                 else:
                     self.ShallowCopy(args[0])
+
+    # Simply bind vtki.plotting.plot to the object
+    plot = plot
 
 
     @property
@@ -95,13 +99,6 @@ class MultiBlock(vtkMultiBlockDataSet):
             if tma > maxi:
                 maxi = tma
         return mini, maxi
-
-
-    def plot(self, **kwargs):
-        """
-        Plots all elements in the multiblock dataset
-        """
-        return vtki.plot(self, **kwargs)
 
 
     def get_index_by_name(self, name):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -963,7 +963,7 @@ class BasePlotter(object):
         self.cubeAxesActor = cubeAxesActor
         return cubeAxesActor
 
-    def set_scale(self, xscale=1.0, yscale=1.0, zscale=1.0):
+    def set_scale(self, xscale=1.0, yscale=1.0, zscale=1.0, resetcam=True):
         """Scale all the datasets in the scene.
         Scaling in performed independently on the X, Y and Z axis.
         A scale of zero is illegal and will be replaced with one.
@@ -974,6 +974,8 @@ class BasePlotter(object):
                 actor.SetScale(xscale, yscale, zscale)
         self.update_bounds_axes()
         self._render()
+        if resetcam:
+            self.reset_camera()
 
     def add_scalar_bar(self, title=None, nlabels=5, italic=False, bold=True,
                        title_fontsize=None, label_fontsize=None, color=None,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -16,7 +16,6 @@ from vtk.util import numpy_support as VN
 import numpy as np
 import vtki
 from vtki.utilities import get_scalar, wrap, is_vtki_obj
-from vtki.container import MultiBlock
 import imageio
 
 
@@ -520,7 +519,7 @@ class BasePlotter(object):
             showedges = rcParams['showedges']
 
 
-        if isinstance(mesh, MultiBlock):
+        if isinstance(mesh, vtki.MultiBlock):
             # frist check the scalars
             if rng is None and scalars is not None:
                 # Get the data range across the array for all blocks if name specified


### PR DESCRIPTION
This little change binds `vtki.plotting.plot` to the `vtki.Common` data objects to make sure arguments and the docstring stay linked. This allows for a much nicer interface in ipython with tab completion and allows us to make changes to `vtki.plotting.plot` without worrying about updating the plot method directly on objects:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/51354982-c417d180-1a72-11e9-9270-f3fb019d897b.gif)


