### PR TITLE
Add ability to cycle through colors when plotting MultiBlock datasets

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -323,7 +323,7 @@ def test_multi_block_plot():
     multi.append(uni)
     # And now add a data set without the desired array and a NULL component
     multi[3] = examples.load_airplane()
-    multi.plot(scalars='Random Data', off_screen=OFF_SCREEN)
+    multi.plot(scalars='Random Data', off_screen=OFF_SCREEN, multi_index=True)
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -323,7 +323,7 @@ def test_multi_block_plot():
     multi.append(uni)
     # And now add a data set without the desired array and a NULL component
     multi[3] = examples.load_airplane()
-    multi.plot(scalars='Random Data', off_screen=OFF_SCREEN, multi_index=True)
+    multi.plot(scalars='Random Data', off_screen=OFF_SCREEN, multi_colors=True)
 
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -426,7 +426,7 @@ class BasePlotter(object):
                  psize=5.0, opacity=1, linethick=None, flipscalars=False,
                  lighting=False, ncolors=256, interpolatebeforemap=False,
                  colormap=None, label=None, resetcam=None, scalar_bar_args={},
-                 **kwargs):
+                 multi_index=False, **kwargs):
         """
         Adds a unstructured, structured, or surface mesh to the plotting object.
 
@@ -502,6 +502,10 @@ class BasePlotter(object):
            applicable for when displaying scalars.  Defaults None
            (rainbow).  Requires matplotlib.
 
+        multi_index : bool, optional
+            If a MultiBlock dataset is given this will color each block by its
+            block index rather than the active scalars.
+
         Returns
         -------
         actor: vtk.vtkActor
@@ -530,6 +534,12 @@ class BasePlotter(object):
                     #       a 2D arrays or list of arrays  where first index
                     #       corresponds to the block? This could get complicated real quick.
                     raise RuntimeError('Scalar array must be given as a string name for multiblock datasets.')
+            if multi_index:
+                # Compute unique colors for each index of the block
+                import matplotlib as mpl
+                from itertools import cycle
+                cycler = mpl.rcParams['axes.prop_cycle']
+                colors = cycle(cycler)
             # Now iteratively plot each element of the multiblock dataset
             actors = []
             for idx in range(mesh.GetNumberOfBlocks()):
@@ -550,6 +560,8 @@ class BasePlotter(object):
                     ts = None
                 else:
                     ts = scalars
+                if multi_index:
+                    color = next(colors)['color']
                 a = self.add_mesh(data, color=color, style=style,
                              scalars=ts, rng=rng, stitle=stitle, showedges=showedges,
                              psize=psize, opacity=opacity, linethick=linethick,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -426,7 +426,7 @@ class BasePlotter(object):
                  psize=5.0, opacity=1, linethick=None, flipscalars=False,
                  lighting=False, ncolors=256, interpolatebeforemap=False,
                  colormap=None, label=None, resetcam=None, scalar_bar_args={},
-                 multi_index=False, **kwargs):
+                 multi_colors=False, **kwargs):
         """
         Adds a unstructured, structured, or surface mesh to the plotting object.
 
@@ -502,9 +502,9 @@ class BasePlotter(object):
            applicable for when displaying scalars.  Defaults None
            (rainbow).  Requires matplotlib.
 
-        multi_index : bool, optional
-            If a MultiBlock dataset is given this will color each block by its
-            block index rather than the active scalars.
+        multi_colors : bool, optional
+            If a ``MultiBlock`` dataset is given this will color each block by
+            a solid color using matplotlib's color cycler.
 
         Returns
         -------
@@ -534,7 +534,7 @@ class BasePlotter(object):
                     #       a 2D arrays or list of arrays  where first index
                     #       corresponds to the block? This could get complicated real quick.
                     raise RuntimeError('Scalar array must be given as a string name for multiblock datasets.')
-            if multi_index:
+            if multi_colors:
                 # Compute unique colors for each index of the block
                 import matplotlib as mpl
                 from itertools import cycle
@@ -560,7 +560,7 @@ class BasePlotter(object):
                     ts = None
                 else:
                     ts = scalars
-                if multi_index:
+                if multi_colors:
                     color = next(colors)['color']
                 a = self.add_mesh(data, color=color, style=style,
                              scalars=ts, rng=rng, stitle=stitle, showedges=showedges,


### PR DESCRIPTION
An optional argument to give each block in a `MultiBlock` dataset a color:

```py
multi = vtki.MultiBlock()
# Add a bunch of datasets ...
multi.plot(multi_colors=True)
```

![download](https://user-images.githubusercontent.com/22067021/51417299-9b5b0f00-1b3a-11e9-9853-2755b6e568dd.png)
