### PR TITLE
Keep track of actors by name

### DIFF
--- a/vtki/qt_plotting.py
+++ b/vtki/qt_plotting.py
@@ -172,8 +172,8 @@ class BackgroundPlotter(QtInteractor):
         self.app.quit()
         self.close()
 
-    def add_actor(self, actor, reset_camera=None):
-        actor, prop = super(BackgroundPlotter, self).add_actor(actor, reset_camera)
+    def add_actor(self, actor, reset_camera=None, name=None):
+        actor, prop = super(BackgroundPlotter, self).add_actor(actor, reset_camera, name)
         if reset_camera:
             self.reset_camera()
         self.update_app_icon()


### PR DESCRIPTION
The plotter now stores pointers to all actors by a string name so that users can specify names for their rendered data and update that data easily by passing a `name` argument to `add_mesh`. 

In the following gif, I show how a user can continually call `add_mesh` with a constant `name` to remove the old actor and add the new one. 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/51433327-3cae9780-1c05-11e9-9fcc-771e47368f26.gif)



