### PR TITLE
Add a textures property to keep track of associated textures

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -342,3 +342,11 @@ def test_plot_texture():
     plotter = vtki.Plotter(off_screen=OFF_SCREEN)
     plotter.add_mesh(globe, texture=texture)
     plotter.plot()
+
+@pytest.mark.skipif(not running_xserver(), reason="Requires X11")
+def test_plot_texture_associated():
+    """"Test adding a texture to a plot"""
+    globe = examples.load_globe()
+    plotter = vtki.Plotter(off_screen=OFF_SCREEN)
+    plotter.add_mesh(globe, texture=True)
+    plotter.plot()

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -93,6 +93,16 @@ class Common(DataSetFilters):
         self.GetPointData().SetTCoords(vtkarr)
         return
 
+    @property
+    def textures(self):
+        """A dictionary to hold ``vtk.vtkTexture`` objects that can be
+        associated with this dataset. When casting back to a VTK dataset or
+        filtering this dataset, these textures will not be passed.
+        """
+        if not hasattr(self, '_textures'):
+            self._textures = {}
+        return self._textures
+
     def set_active_scalar(self, name, preference='cell'):
         """Finds the scalar by name and appropriately sets it as active"""
         arr, field = get_scalar(self, name, preference=preference, info=True)

--- a/vtki/examples/examples.py
+++ b/vtki/examples/examples.py
@@ -63,7 +63,9 @@ def load_structured():
 
 def load_globe():
     """ Loads a globe source """
-    return vtki.PolyData(globefile)
+    globe = vtki.PolyData(globefile)
+    globe.textures['2k_earth_daymap'] = load_globe_texture()
+    return globe
 
 def load_globe_texture():
     """ Loads a vtk.vtkTexture that can be applied to the globe source """

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -621,10 +621,15 @@ class BasePlotter(object):
         elif isinstance(texture, str):
             # Grab a texture by name
             try:
-                texture = mesh.textures[texture]
+                tname = texture
+                texture = mesh.textures[tname]
             except KeyError:
                 logging.warning('Texture ({}) not associated with this dataset'.format(texture))
                 texture = None
+            else:
+                # Be sure to set the tcoords if present
+                if tname in mesh.scalar_names:
+                    mesh.GetPointData().SetTCoords(mesh.GetPointData().GetArray(tname))
 
         if texture is not None:
             if isinstance(texture, np.ndarray):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -511,9 +511,10 @@ class BasePlotter(object):
             If an actor of this name already exists in the rendering window, it
             will be replaced by the new actor.
 
-        texture : vtk.vtkTexture or np.ndarray, optional
+        texture : vtk.vtkTexture or np.ndarray or boolean, optional
             A texture to apply if the input mesh has texture coordinates.
-            This will not work with MultiBlock datasets.
+            This will not work with MultiBlock datasets. If set to ``True``,
+            the first avaialble texture on the object will be used.
 
         Returns
         -------
@@ -602,6 +603,18 @@ class BasePlotter(object):
         self.mapper = vtk.vtkDataSetMapper()
         self.mapper.SetInputData(self.mesh)
         actor, prop = self.add_actor(self.mapper, reset_camera=reset_camera, name=name)
+
+        if texture == True:
+            # Grab the first texture availabe
+            try:
+                tname = list(mesh.textures.keys())[0]
+                texture = mesh.textures[tname]
+                # Be sure to set the tcoords if present
+                if tname in mesh.scalar_names:
+                    mesh.GetPointData().SetTCoords(mesh.GetPointData().GetArray(tname))
+            except IndexError:
+                logging.warning('No textures associated with input mesh.')
+                texture = None
 
         if texture is not None:
             if isinstance(texture, np.ndarray):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -514,7 +514,9 @@ class BasePlotter(object):
         texture : vtk.vtkTexture or np.ndarray or boolean, optional
             A texture to apply if the input mesh has texture coordinates.
             This will not work with MultiBlock datasets. If set to ``True``,
-            the first avaialble texture on the object will be used.
+            the first avaialble texture on the object will be used. If a string
+            name is given, it will pull a texture with that name associated to
+            the input mesh.
 
         Returns
         -------
@@ -616,6 +618,13 @@ class BasePlotter(object):
                 # Be sure to set the tcoords if present
                 if tname in mesh.scalar_names:
                     mesh.GetPointData().SetTCoords(mesh.GetPointData().GetArray(tname))
+        elif isinstance(texture, str):
+            # Grab a texture by name
+            try:
+                texture = mesh.textures[texture]
+            except KeyError:
+                logging.warning('Texture ({}) not associated with this dataset'.format(texture))
+                texture = None
 
         if texture is not None:
             if isinstance(texture, np.ndarray):

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -609,12 +609,13 @@ class BasePlotter(object):
             try:
                 tname = list(mesh.textures.keys())[0]
                 texture = mesh.textures[tname]
-                # Be sure to set the tcoords if present
-                if tname in mesh.scalar_names:
-                    mesh.GetPointData().SetTCoords(mesh.GetPointData().GetArray(tname))
             except IndexError:
                 logging.warning('No textures associated with input mesh.')
                 texture = None
+            else:
+                # Be sure to set the tcoords if present
+                if tname in mesh.scalar_names:
+                    mesh.GetPointData().SetTCoords(mesh.GetPointData().GetArray(tname))
 
         if texture is not None:
             if isinstance(texture, np.ndarray):


### PR DESCRIPTION
@akaszynski: Could you approve this (as its adding new properties that doesn't call back to the VTK object)? I need this new property for the [`omfvtk`](https://github.com/OpenGeoVis/omfvtk) project.

It essentially helps a user keep track of `vtkTextures` that could be associated with that dataset. I need it in `omfvtk` because the data files contain both the dataset and the texture. Having this would enable me to pass textures along with the datasets. 

This also allows for easier texture plotting when a texture is associated with a dataset in the new `textures` dictionary property:

```py
>>> from vtki import examples
>>> globe = examples.load_globe()
>>> globe.textures
{'2k_earth_daymap': (vtkRenderingOpenGL2Python.vtkOpenGLTexture)0x11bf878e8}

>>> globe.plot(texture=True)

```

![download](https://user-images.githubusercontent.com/22067021/51561204-dc596900-1e43-11e9-9e9a-139385883868.png)
