### PR TITLE
Update where/how .render is called

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -416,7 +416,7 @@ class BasePlotter(object):
             self.iren.Start()
             self.iren.DestroyTimer(self.right_timer_id)
 
-            self.render()
+            self._render()
             Plotter.last_update_time = curr_time
         else:
             if force_redraw:
@@ -1320,7 +1320,7 @@ class BasePlotter(object):
         mesh.points = points
 
         if render:
-            self.render()
+            self._render()
 
     def close(self):
         """ closes render window """


### PR DESCRIPTION
Note there was an issue with calls to `self.redner()` in the plotter code. This should be fixed now.

@akaszynski, can we push out `0.16.1` to patch this if all looks good to you?

And here is a version of the wave example that is interactive!

```py
import vtki
import numpy as np
from threading import Thread
import time

x = np.arange(-10, 10, 0.25)
y = np.arange(-10, 10, 0.25)
x, y = np.meshgrid(x, y)
r = np.sqrt(x**2 + y**2)
z = np.sin(r)

# Create and structured surface
grid = vtki.StructuredGrid(x, y, z)

# Creat a plotter object and set the scalars to the Z height
p = vtki.BackgroundPlotter()
p.add_mesh(grid, scalars=z.ravel())

pts = grid.points.copy()

# Update Z through time
RUN = True
nframe = 25
tstep = 0.01

def update():
    while RUN:
        for phase in np.linspace(0, 2*np.pi, nframe + 1)[:nframe]:
            z = np.sin(r + phase)
            pts[:, -1] = z.ravel()
            p.update_coordinates(pts)
            p.update_scalars(z.ravel())
            time.sleep(tstep)
    return None
        
update_thread = Thread(target=update)
update_thread.start()

# And then when you're ready to stop it:
RUN = False
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22067021/51806498-afd49100-2237-11e9-8485-d7564fc34a1c.gif)
