### PR TITLE
Change default for show_edges to false.

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -52,7 +52,7 @@ rcParams = {
         'position_x' : 0.35,
         'position_y' : 0.02,
     },
-    'show_edges' : True,
+    'show_edges' : False,
 }
 
 def set_plot_theme(theme):


### PR DESCRIPTION
Can we do this, @akaszynski? I suppose you prefer the show_edges for your datasets but I'm realizing almost 9/10 times I plot something I need the edges to be off because the datasets are too big and the edges overwhelm the dataset:

![edges](https://user-images.githubusercontent.com/22067021/52017677-51144f00-24a5-11e9-8508-56e522b81e81.png)

vs.

![no-edges](https://user-images.githubusercontent.com/22067021/52017676-51144f00-24a5-11e9-873b-834f8be2d2d4.png)
