### PR TITLE
Use absolute filenames for IO

### DIFF
--- a/vtki/container.py
+++ b/vtki/container.py
@@ -54,6 +54,7 @@ class MultiBlock(vtkMultiBlockDataSet):
         """Load a vtkMultiBlockDataSet from a file (extension ``.vtm`` or
         ``.vtmb``)
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # test if file exists
         if not os.path.isfile(filename):
             raise Exception('File %s does not exist' % filename)
@@ -100,6 +101,7 @@ class MultiBlock(vtkMultiBlockDataSet):
         Binary files write much faster than ASCII and have a smaller
         file size.
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         ext = os.path.splitext(filename)[1].lower()
         if ext in ['.vtm', '.vtmb']:
             writer = vtk.vtkXMLMultiBlockDataWriter()

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -152,6 +152,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
             Filename of grid to be loaded.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # check file exists
         if not os.path.isfile(filename):
             raise Exception('%s does not exist')
@@ -199,6 +200,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         only with the legacy writer.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkRectilinearGridWriter()
@@ -411,6 +413,7 @@ class UniformGrid(vtkImageData, Grid):
             Filename of grid to be loaded.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # check file exists
         if not os.path.isfile(filename):
             raise Exception('%s does not exist')
@@ -458,6 +461,7 @@ class UniformGrid(vtkImageData, Grid):
         only with the legacy writer.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkDataSetWriter()

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -123,6 +123,7 @@ class PolyData(vtkPolyData, vtki.Common):
         Binary files load much faster than ASCII.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # test if file exists
         if not os.path.isfile(filename):
             raise Exception('File %s does not exist' % filename)
@@ -475,6 +476,7 @@ class PolyData(vtkPolyData, vtki.Common):
         Binary files write much faster than ASCII and have a smaller
         file size.
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # Check filetype
         ftype = filename[-3:]
         if ftype == 'ply':
@@ -1634,6 +1636,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid):
         filename : str
             Filename of grid to be loaded.
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # check file exists
         if not os.path.isfile(filename):
             raise Exception('%s does not exist' % filename)
@@ -1673,6 +1676,7 @@ class UnstructuredGrid(vtkUnstructuredGrid, PointGrid):
         one system may not be readable on other systems.  Binary can be used
         only ".vtk" files
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkUnstructuredGridWriter()
@@ -1997,6 +2001,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
             Filename of grid to be loaded.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # check file exists
         if not os.path.isfile(filename):
             raise Exception('%s does not exist')
@@ -2044,6 +2049,7 @@ class StructuredGrid(vtkStructuredGrid, PointGrid):
         only with the legacy writer.
 
         """
+        filename = os.path.abspath(os.path.expanduser(filename))
         # Use legacy writer if vtk is in filename
         if '.vtk' in filename:
             writer = vtk.vtkStructuredGridWriter()

--- a/vtki/utilities.py
+++ b/vtki/utilities.py
@@ -215,6 +215,7 @@ def read(filename):
     """This will read any VTK file! It will figure out what reader to use
     then wrap the VTK object for use in ``vtki``
     """
+    filename = os.path.abspath(os.path.expanduser(filename))
     def legacy(filename):
         reader = vtk.vtkDataSetReader()
         reader.SetFileName(filename)
@@ -249,6 +250,7 @@ def read(filename):
 
 def setErrorOutputFile(filename):
     """Sets a file to write out the VTK errors"""
+    filename = os.path.abspath(os.path.expanduser(filename))
     fileOutputWindow = vtk.vtkFileOutputWindow()
     fileOutputWindow.SetFileName(filename)
     outputWindow = vtk.vtkOutputWindow()
@@ -258,6 +260,7 @@ def setErrorOutputFile(filename):
 
 def load_texture(filename):
     """Loads a ``vtkTexture`` from an image file."""
+    filename = os.path.abspath(os.path.expanduser(filename))
     ext = os.path.splitext(filename)[1].lower()
     if ext in ['.jpg', '.jpeg']:
         reader = vtk.vtkJPEGReader()


### PR DESCRIPTION
Whenever using IO functions from the VTK library, pass absolute file names such that we can now pass paths that include the home directory (`'~/'`):
```python
dataset.save('~/Desktop/astroid.vtk')
```
which will expand and save to where it is expected.