### PR TITLE
Update axes bounds

### DIFF
--- a/notebooks/Background-Plotting.ipynb
+++ b/notebooks/Background-Plotting.ipynb
@@ -86,7 +86,7 @@
     {
      "data": {
       "text/plain": [
-       "(vtkRenderingAnnotationPython.vtkCubeAxesActor)0x1295ad708"
+       "(vtkRenderingAnnotationPython.vtkcube_axes_actor)0x1295ad708"
       ]
      },
      "execution_count": 5,

--- a/notebooks/Background-Plotting.ipynb
+++ b/notebooks/Background-Plotting.ipynb
@@ -86,7 +86,7 @@
     {
      "data": {
       "text/plain": [
-       "(vtkRenderingAnnotationPython.vtkcube_axes_actor)0x1295ad708"
+       "(vtkRenderingAnnotationPython.vtkCubeAxesActor)0x1295ad708"
       ]
      },
      "execution_count": 5,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -301,7 +301,7 @@ class BasePlotter(object):
             return
 
         for name, actor in self._actors.items():
-            if isinstance(actor, vtk.vtkcube_axes_actor):
+            if isinstance(actor, vtk.vtkCubeAxesActor):
                 continue
             if hasattr(actor, 'GetBounds') and actor.GetBounds() is not None:
                 _update_bounds(actor.GetBounds())
@@ -975,7 +975,7 @@ class BasePlotter(object):
 
         Returns
         -------
-        cube_axes_actor : vtk.vtkcube_axes_actor
+        cube_axes_actor : vtk.vtkCubeAxesActor
             Bounds actor
 
         """
@@ -994,7 +994,7 @@ class BasePlotter(object):
             bounds = self.bounds
 
         # create actor
-        cube_axes_actor = vtk.vtkcube_axes_actor()
+        cube_axes_actor = vtk.vtkCubeAxesActor()
         cube_axes_actor.SetUse2DMode(False)
         cube_axes_actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
 

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -963,9 +963,11 @@ class BasePlotter(object):
             of the axes actor.
 
         location : str, optional
-            Set how the axes are drawn: either static, closest triad, furthest
-            triad or outer edges in relation to the camera position. Options
-            include: ``'all', 'origin', 'outer', 'front', 'back'``
+            Set how the axes are drawn: either static (``'all'``), closest triad
+            (``front``), furthest triad (``'back'``), static closest to the
+            origin (``'origin'``), or outer edges (``'outer'``) in relation to
+            the camera position. Options include:
+            ``'all', 'front', 'back', 'origin', 'outer'``
 
         ticks : str, option
             Set how the ticks are drawn on the axes grid. Options include:


### PR DESCRIPTION
Some updates to add more controls to the axis bounds. Enables a grid to be drawn, ticks in inside/outside/both, and ability to control the location of the grid. See the docs for `vtki.Plotter.add_bounds_axes` for more details.

```py
import vtki
from vtki import examples

data = examples.load_uniform()

tool = vtki.OrthogonalSlicer(data)

tool.plotter.add_bounds_axes(grid=True, location='outer', ticks='both')
```

![img](https://user-images.githubusercontent.com/22067021/52391698-d24a8380-2a5b-11e9-9b62-1da4cd8d123e.png)
