### PR TITLE
Call Modified on data after using interfaced setters

### DIFF
--- a/vtki/common.py
+++ b/vtki/common.py
@@ -72,6 +72,7 @@ class Common(DataSetFilters):
         vtk_points = vtki.vtk_points(points, False)
         self.SetPoints(vtk_points)
         self.GetPoints().Modified()
+        self.Modified()
 
     @property
     def t_coords(self):
@@ -688,6 +689,8 @@ class CellScalarsDict(dict):
         if self.callback_enabled:
             self.data._add_cell_scalar(val, key, deep=False)
         dict.__setitem__(self, key, val)
+        self.data.GetCellData().Modified()
+        # self.data.Modified()
 
     def __delitem__(self, key):
         self.data._remove_cell_scalar(key)
@@ -713,6 +716,8 @@ class PointScalarsDict(dict):
         if self.callback_enabled:
             self.data._add_point_scalar(val, key, deep=False)
         dict.__setitem__(self, key, val)
+        self.data.GetPointData().Modified()
+        # self.data.Modified()
 
     def __delitem__(self, key):
         self.data._remove_point_scalar(key)

--- a/vtki/common.py
+++ b/vtki/common.py
@@ -71,6 +71,7 @@ class Common(DataSetFilters):
             raise TypeError('Points must be a numpy array')
         vtk_points = vtki.vtk_points(points, False)
         self.SetPoints(vtk_points)
+        self.GetPoints().Modified()
 
     @property
     def t_coords(self):
@@ -94,6 +95,7 @@ class Common(DataSetFilters):
         vtkarr = numpy_to_vtk(t_coords)
         vtkarr.SetName('Texture Coordinates')
         self.GetPointData().SetTCoords(vtkarr)
+        self.GetPointData().Modified()
         return
 
     @property

--- a/vtki/container.py
+++ b/vtki/container.py
@@ -157,6 +157,7 @@ class MultiBlock(vtkMultiBlockDataSet):
     def n_blocks(self, n):
         """The total number of blocks set"""
         self.SetNumberOfBlocks(n)
+        self.Modified()
 
 
     def get_data_range(self, name):

--- a/vtki/grid.py
+++ b/vtki/grid.py
@@ -33,6 +33,7 @@ class Grid(vtki.Common):
         """Sets the dataset dimensions. Pass a length three tuple of integers"""
         nx, ny, nz = dims[0], dims[1], dims[2]
         self.SetDimensions(nx, ny, nz)
+        self.Modified()
 
 
 class RectilinearGrid(vtkRectilinearGrid, Grid):
@@ -136,6 +137,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
         # Set the vtk coordinates
         self._from_arrays(x, y, z)
         #self._point_ref = points
+        self.Modified()
 
 
     def _load_file(self, filename):
@@ -227,6 +229,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
     def x(self, coords):
         """Set the coordinates along the X-direction"""
         self.SetXCoordinates(numpy_to_vtk(coords))
+        self.Modified()
 
     @property
     def y(self):
@@ -237,6 +240,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
     def y(self, coords):
         """Set the coordinates along the Y-direction"""
         self.SetYCoordinates(numpy_to_vtk(coords))
+        self.Modified()
 
     @property
     def z(self):
@@ -248,6 +252,7 @@ class RectilinearGrid(vtkRectilinearGrid, Grid):
     def z(self, coords):
         """Set the coordinates along the Z-direction"""
         self.SetZCoordinates(numpy_to_vtk(coords))
+        self.Modified()
 
 
     # @property
@@ -397,6 +402,7 @@ class UniformGrid(vtkImageData, Grid):
         # Build the vtk object
         self._from_specs((nx,ny,nz), (dx,dy,dz), (ox,oy,oz))
         #self._point_ref = points
+        self.Modified()
 
 
     def _load_file(self, filename):
@@ -501,6 +507,7 @@ class UniformGrid(vtkImageData, Grid):
         """Set the origin. Pass a length three tuple of floats"""
         ox, oy, oz = origin[0], origin[1], origin[2]
         self.SetOrigin(ox, oy, oz)
+        self.Modified()
 
     @property
     def spacing(self):
@@ -513,3 +520,4 @@ class UniformGrid(vtkImageData, Grid):
         floats"""
         dx, dy, dz = spacing[0], spacing[1], spacing[2]
         self.SetSpacing(dx, dy, dz)
+        self.Modified()

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -180,6 +180,7 @@ class PolyData(vtkPolyData, vtki.Common):
         else:
             self.SetPolys(vtkcells)
         self._face_ref = faces
+        self.Modified()
 
     # @property
     # def lines(self):


### PR DESCRIPTION
Call Modified when updating datasets. This enables data that has already been added to a Plotter to be updated without calling the `update_scalars` or `update_coordinates` routines. A user might want this if they have several datasets in one scene and they need to update parts of some of those datasets.

For example, the wave example can now be done as:

```py
import vtki
import numpy as np
from threading import Thread
import time

x = np.arange(-10, 10, 0.25)
y = np.arange(-10, 10, 0.25)
x, y = np.meshgrid(x, y)
r = np.sqrt(x**2 + y**2)
z = np.sin(r)

# Create and structured surface
grid = vtki.StructuredGrid(x, y, z)
grid.point_arrays['data'] = z.ravel()

# Create a plotter object and set the scalars to the Z height
p = vtki.BackgroundPlotter()
p.add_mesh(grid)

# Update Z through time
RUN = True
nframe = 25
tstep = 0.05

def update():
    while RUN:
        for phase in np.linspace(0, 2*np.pi, nframe + 1)[:nframe]:
            z = np.sin(r + phase)
            grid.points[:, -1] = z.ravel()
            grid.point_arrays['data'] = z.ravel()
            time.sleep(tstep)
    return None
        
update_thread = Thread(target=update)
update_thread.start()

```

```py
# And then when you're ready to stop it:
RUN = False
```