### PR TITLE
Update links to new website: http://www.vtki.org/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ vtki
    :target: https://ci.appveyor.com/project/akaszynski/vtkinterface/history
 
 .. image:: https://img.shields.io/readthedocs/vtkinterface.svg?logo=read%20the%20docs&logoColor=white
-   :target: https://vtkinterface.readthedocs.io/en/latest/
+   :target: http://www.vtki.org/
 
 .. image:: https://img.shields.io/github/contributors/akaszynski/vtki.svg?logo=github&logoColor=white
    :target: https://GitHub.com/akaszynski/vtki/graphs/contributors/
@@ -28,7 +28,7 @@ papers as well as a supporting module for other mesh dependent Python modules.
 
 Documentation
 -------------
-Refer to the `Read the Docs <http://vtkInterface.readthedocs.io/en/latest/index.html>`_
+Refer to the `Read the Docs <http://www.vtki.org/>`_
 documentation for detailed installation and usage details.
 
 Also see the `wiki <https://github.com/akaszynski/vtki/wiki>`_ for brief code
@@ -43,7 +43,7 @@ Installation is simply::
 You can also visit `PyPi <http://pypi.python.org/pypi/vtki>`_ or
 `GitHub <https://github.com/akaszynski/vtki>`_ to download the source.
 
-See the `Installation <http://vtkInterface.readthedocs.io/en/latest/getting-started/installation.html#install-ref.>`_
+See the `Installation <http://www.vtki.org/latest/getting-started/installation.html#install-ref.>`_
 for more details if the installation through pip doesn't work out.
 
 
@@ -53,7 +53,7 @@ Highlights
 Head over to the `Quick Examples`_ page in the docs to learn more about using
 ``vtki``.
 
-.. _Quick Examples: https://vtkinterface.readthedocs.io/en/latest/examples/index.html
+.. _Quick Examples: http://www.vtki.org/en/latest/examples/index.html
 
 * Pythonic interface to VTK's Python-C++ bindings
 * Filtering/plotting tools built for interactivity in Jupyter notebooks (see `IPython Tools`_)
@@ -61,9 +61,9 @@ Head over to the `Quick Examples`_ page in the docs to learn more about using
 * Intuitive plotting routines with ``matplotlib`` similar syntax (see Plotting_)
 
 
-.. _IPython Tools: https://vtkinterface.readthedocs.io/en/latest/tools/ipy_tools.html
-.. _Filters: https://vtkinterface.readthedocs.io/en/latest/tools/filters.html
-.. _Plotting: https://vtkinterface.readthedocs.io/en/latest/tools/plotting.html
+.. _IPython Tools: http://www.vtki.org/en/latest/tools/ipy_tools.html
+.. _Filters: http://www.vtki.org/en/latest/tools/filters.html
+.. _Plotting: http://www.vtki.org/en/latest/tools/plotting.html
 
 
 Connections


### PR DESCRIPTION
Check out the new domain http://www.vtki.org/ where the documentation is hosted.

Note: I have also added email forwarding on that domain which we will need to set up for user support per the JOSS submission guidelines.

Currently, support@vtki.org forwards to my email. Perhaps we create an actual email account under the vtki.org domain that active maintainers can access?