### PR TITLE
Fixing scaling issues with cube axes actor

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -1052,7 +1052,10 @@ class BasePlotter(object):
 
         # create actor
         cube_axes_actor = vtk.vtkCubeAxesActor()
-        cube_axes_actor.SetUse2DMode(False)
+        if not np.allclose(self.scale, [1.0, 1.0, 1.0]):
+            cube_axes_actor.SetUse2DMode(True)
+        else:
+            cube_axes_actor.SetUse2DMode(False)
 
         if grid:
             if isinstance(grid, str) and grid.lower() in ('front', 'frontface'):
@@ -1197,6 +1200,10 @@ class BasePlotter(object):
         """Update the bounds axes of the render window """
         if hasattr(self, 'cube_axes_actor'):
             self.cube_axes_actor.SetBounds(self.bounds)
+            if not np.allclose(self.scale, [1.0, 1.0, 1.0]):
+                self.cube_axes_actor.SetUse2DMode(True)
+            else:
+                self.cube_axes_actor.SetUse2DMode(False)
         if hasattr(self, 'bounding_box_actor'):
             color = self.bounding_box_actor.GetProperty().GetColor()
             self.remove_bounding_box()
@@ -1241,6 +1248,7 @@ class BasePlotter(object):
         cam.SetModelTransformMatrix(transform.GetMatrix())
         self._render()
         if reset_camera:
+            self.update_bounds_axes()
             self.reset_camera()
 
     def add_scalar_bar(self, title=None, n_labels=5, italic=False, bold=True,

--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -839,10 +839,6 @@ class BasePlotter(object):
         else:
             actor = uinput
 
-        # Make sure scale is consistent with rest of scene
-        if hasattr(actor, 'SetScale'):
-            actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
-
         self.renderer.AddActor(actor)
         if name is None:
             name = str(hex(id(actor)))
@@ -1059,7 +1055,6 @@ class BasePlotter(object):
         # create actor
         cube_axes_actor = vtk.vtkCubeAxesActor()
         cube_axes_actor.SetUse2DMode(False)
-        cube_axes_actor.SetScale(self.scale[0], self.scale[1], self.scale[2])
 
         if grid:
             if isinstance(grid, str) and grid.lower() in ('front', 'frontface'):
@@ -1202,10 +1197,11 @@ class BasePlotter(object):
         if zscale is None:
             zscale = self.scale[2]
         self.scale = [xscale, yscale, zscale]
-        for name, actor in self._actors.items():
-            if hasattr(actor, 'SetScale'):
-                actor.SetScale(xscale, yscale, zscale)
-        self.update_bounds_axes()
+        # Update the camera's coordinate system
+        cam = self.renderer.GetActiveCamera()
+        transform = vtk.vtkTransform()
+        transform.Scale(xscale, yscale, zscale)
+        cam.SetModelTransformMatrix(transform.GetMatrix())
         self._render()
         if reset_camera:
             self.reset_camera()


### PR DESCRIPTION
This changes the scene scaling to actually scale the coordinate system not the points of all the actors. See [this discussion](https://discourse.vtk.org/t/scaling-a-rendering-scene/173/6) for more details.

Note that we still need a better solution for how the cube axes actor is displayed when the scene is scaled as now I force the `vtkCubeAxesActor` to use `SetUse2DMode(True)` if the scale is not the default `(1,1,1)`.