### PR TITLE
removed PyQt5.Qt import due to bluetooth bug

### DIFF
--- a/tests/test_ipy_tools.py
+++ b/tests/test_ipy_tools.py
@@ -10,8 +10,6 @@ from vtki import examples
 
 try:
     import PyQt5
-    from PyQt5 import Qt
-    from PyQt5.Qt import QMainWindow
     has_pyqt5 = True
 except:
     has_pyqt5 = False

--- a/tests/test_qt_plotting.py
+++ b/tests/test_qt_plotting.py
@@ -7,10 +7,15 @@ import vtki
 from vtki import QtInteractor
 from vtki.plotting import running_xserver
 
+
+# dummy class to allow module init
+class QMainWindow(object):
+    pass
+
+
 try:
     import PyQt5
-    from PyQt5 import Qt
-    from PyQt5.Qt import QMainWindow
+    from PyQt5.Qt import (QMainWindow, QFrame, QVBoxLayout, QAction)
     has_pyqt5 = True
 except:
     has_pyqt5 = False
@@ -21,10 +26,10 @@ except:
 class MainWindow(QMainWindow):
 
     def __init__(self, parent=None, show=True):
-        Qt.QMainWindow.__init__(self, parent)
+        QMainWindow.__init__(self, parent)
 
-        self.frame = Qt.QFrame()
-        vlayout = Qt.QVBoxLayout()
+        self.frame = QFrame()
+        vlayout = QVBoxLayout()
         self.vtk_widget = QtInteractor(self.frame)
         vlayout.addWidget(self.vtk_widget)
 
@@ -34,14 +39,14 @@ class MainWindow(QMainWindow):
         mainMenu = self.menuBar()
         fileMenu = mainMenu.addMenu('File')
 
-        exitButton = Qt.QAction('Exit', self)
+        exitButton = QAction('Exit', self)
         exitButton.setShortcut('Ctrl+Q')
         exitButton.triggered.connect(self.close)
 
         fileMenu.addAction(exitButton)
 
         meshMenu = mainMenu.addMenu('Mesh')
-        self.add_sphere_action = Qt.QAction('Add Sphere', self)
+        self.add_sphere_action = QAction('Add Sphere', self)
 
         self.add_sphere_action.triggered.connect(self.add_sphere)
         meshMenu.addAction(self.add_sphere_action)
@@ -72,10 +77,3 @@ def test_background_plotting(qtbot):
     plotter.add_mesh(sphere)
     assert np.any(plotter.mesh.points)
     assert plotter.close()
-
-
-
-# if __name__ == '__main__':
-#     app = Qt.QApplication(sys.argv)
-#     window = MainWindow()
-#     sys.exit(app.exec_())


### PR DESCRIPTION
@banesullivan,

Found out what was causing the appveyor build to fail:

```python
try:
    import PyQt5
    from PyQt5 import Qt  # <<-- loads bluetooth drivers
    from PyQt5.Qt import QMainWindow
    has_pyqt5 = True
except:
    has_pyqt5 = False
```

Turns out that importing ``Qt`` loads a ton of libraries, including bluetooth which isn't supported on the Windows Server.  Worst of all, being windows, a pop-up dialog shows up and hangs the collection so we can't tell where or why it happened.  I had to look back to old commits to see the commit that started killing appveyor.