### PR TITLE
Make `rng` more flexible.

### DIFF
--- a/vtki/plotting.py
+++ b/vtki/plotting.py
@@ -728,7 +728,7 @@ class BasePlotter(object):
                 _raise_not_matching(scalars, mesh)
 
             # Set scalar range
-            if not rng:
+            if rng is None:
                 rng = [np.nanmin(scalars), np.nanmax(scalars)]
             elif isinstance(rng, float) or isinstance(rng, int):
                 rng = [-rng, rng]


### PR DESCRIPTION
Currently, `vtki` fails if a numpy-array of two elements is provided to `rng`, with the error 
```
    723             # Set scalar range
--> 724             if not rng:
    725                 rng = [np.nanmin(scalars), np.nanmax(scalars)]
    726             elif isinstance(rng, float) or isinstance(rng, int):

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Changing `if not range` to `if range is None` solves that.