### PR TITLE
Fix Travis PyQt5 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - pip install codecov
   - |
     if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then
-      pip install PyQt5<5.12;
+      pip install PyQt5;
       pip install pytest-qt;
       pip install nbval; # For testing the notebooks
       pip install ipywidgets;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - pip install codecov
   - |
     if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then
-      pip install PyQt5;
+      pip install PyQt5==5.11.3;
       pip install pytest-qt;
       pip install nbval; # For testing the notebooks
       pip install ipywidgets;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ install:
   - pip install codecov
   - |
     if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then
-      pip install PyQt5<5.12 pytest-qt;
+      pip install PyQt5<5.12;
+      pip install pytest-qt;
       pip install nbval; # For testing the notebooks
       pip install ipywidgets;
     fi


### PR DESCRIPTION
Force Travis to use `v5.11.3` of PyQt5 so that all the PyQt5 code will be automatically tested