### PR TITLE
Support all VTK readers

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -397,7 +397,7 @@ def test_plot_texture_associated():
     plotter.plot()
 
 @pytest.mark.skipif(not running_xserver(), reason="Requires X11")
-def test_load_texture_from_numpy():
+def test_read_texture_from_numpy():
     """"Test adding a texture to a plot"""
     globe = examples.load_globe()
     texture = vtki.numpy_to_texture(imageio.imread(examples.mapfile))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -7,6 +7,7 @@ import pytest
 import vtki
 from vtki import examples as ex
 from vtki import utilities
+from vtki import readers
 
 # Only set this here just the once.
 utilities.set_error_output_file(os.path.join(os.path.dirname(__file__), 'ERROR_OUTPUT.txt'))
@@ -41,7 +42,7 @@ def test_read(tmpdir):
     types = (vtki.PolyData, vtki.PolyData, vtki.UnstructuredGrid,
              vtki.PolyData, vtki.UniformGrid, vtki.RectilinearGrid)
     for i, filename in enumerate(fnames):
-        obj = utilities.read(filename)
+        obj = readers.read(filename)
         assert isinstance(obj, types[i])
     # this is also tested for each mesh types init from file tests
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % 'npy'))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -44,6 +44,11 @@ def test_read(tmpdir):
     for i, filename in enumerate(fnames):
         obj = readers.read(filename)
         assert isinstance(obj, types[i])
+    # Now test the standard_reader_routine
+    for i, filename in enumerate(fnames):
+        # Pass attrs to for the standard_reader_routine to be used
+        obj = readers.read(filename, attrs={'DebugOn': None})
+        assert isinstance(obj, types[i])
     # this is also tested for each mesh types init from file tests
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.%s' % 'npy'))
     arr = np.random.rand(10, 10)

--- a/vtki/__init__.py
+++ b/vtki/__init__.py
@@ -2,6 +2,7 @@ import warnings
 from vtki._version import __version__
 from vtki.plotting import *
 from vtki.utilities import *
+from vtki.readers import *
 from vtki.colors import *
 from vtki.filters import DataSetFilters
 from vtki.common import Common

--- a/vtki/container.py
+++ b/vtki/container.py
@@ -11,6 +11,7 @@ import numpy as np
 import vtk
 from vtk import vtkMultiBlockDataSet
 
+import vtki
 from vtki import plot
 from vtki.utilities import get_scalar, is_vtki_obj, wrap
 
@@ -89,7 +90,7 @@ class MultiBlock(vtkMultiBlockDataSet):
             raise Exception('File %s does not exist' % filename)
 
         # Get extension
-        ext = os.path.splitext(filename)[1].lower()
+        ext = vtki.get_ext(filename)
         # Extensions: .vtm and .vtmb
 
         # Select reader
@@ -126,7 +127,7 @@ class MultiBlock(vtkMultiBlockDataSet):
         file size.
         """
         filename = os.path.abspath(os.path.expanduser(filename))
-        ext = os.path.splitext(filename)[1].lower()
+        ext = vtki.get_ext(filename)
         if ext in ['.vtm', '.vtmb']:
             writer = vtk.vtkXMLMultiBlockDataWriter()
         else:

--- a/vtki/examples/examples.py
+++ b/vtki/examples/examples.py
@@ -66,7 +66,7 @@ def load_globe():
 
 def load_globe_texture():
     """ Loads a vtk.vtkTexture that can be applied to the globe source """
-    return vtki.load_texture(mapfile)
+    return vtki.read_texture(mapfile)
 
 def plot_ants_plane(off_screen=False, notebook=None):
     """

--- a/vtki/pointset.py
+++ b/vtki/pointset.py
@@ -121,7 +121,7 @@ class PolyData(vtkPolyData, vtki.Common):
             raise Exception('File %s does not exist' % filename)
 
         # Get extension
-        ext = os.path.splitext(filename)[1].lower()
+        ext = vtki.get_ext(filename)
 
         # Select reader
         if ext == '.ply':

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -30,7 +30,44 @@ READERS = {
     '.slc': vtk.vtkSLCReader,
     '.tiff': vtk.vtkTIFFReader,
     '.tif': vtk.vtkTIFFReader,
+    # ExodusII files:
+    #.g, .e, .ex2, .ex2v2, .exo, .gen, .exoII, .exii, .0, .00, .000
+    '.g': vtk.vtkExodusIIReader,
+    '.e': vtk.vtkExodusIIReader,
+    '.ex2': vtk.vtkExodusIIReader,
+    '.ex2v2': vtk.vtkExodusIIReader,
+    '.exo': vtk.vtkExodusIIReader,
+    '.gen': vtk.vtkExodusIIReader,
+    '.exoii': vtk.vtkExodusIIReader,
+    '.exii': vtk.vtkExodusIIReader,
+    '.0': vtk.vtkExodusIIReader,
+    '.00': vtk.vtkExodusIIReader,
+    '.000': vtk.vtkExodusIIReader,
+    # Other formats:
+    '.byu': vtk.vtkBYUReader,
+    '.chemml': vtk.vtkCMLMoleculeReader,
+    '.cml': vtk.vtkCMLMoleculeReader,
+    # TODO: '.csv': vtk.vtkCSVReader, # vtkTables are currently not supported
+    '.facet': vtk.vtkFacetReader,
+    '.cas': vtk.vtkFLUENTReader,
+    '.dat': vtk.vtkFLUENTReader,
+    '.cube': vtk.vtkGaussianCubeReader,
+    '.res': vtk.vtkMFIXReader,
+    '.foam': vtk.vtkOpenFOAMReader,
+    '.pdb': vtk.vtkPDBReader,
+    '.p3d': vtk.vtkPlot3DMetaReader,
+    '.pts': vtk.vtkPTSReader,
+    '.particles': vtk.vtkParticleReader,
+    #TODO: '.pht': vtk.vtkPhasta??????,
+    #TODO: '.vpc': vtk.vtkVPIC?????,
+    '.xyz': vtk.vtkXYZMolReader,
 }
+
+
+if (vtk.vtkVersion().GetVTKMajorVersion() >= 8 and
+    vtk.vtkVersion().GetVTKMinorVersion() >= 2):
+    READERS['.sgy'] = vtk.vtkSegYReader
+    READERS['.segy'] = vtk.vtkSegYReader
 
 
 def get_ext(filename):
@@ -81,7 +118,6 @@ def standard_reader_routine(reader, filename, attrs=None):
     # Perform the read
     reader.Update()
     return vtki.wrap(reader.GetOutputDataObject(0))
-
 
 
 def read_legacy(filename):

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -141,9 +141,11 @@ def read(filename, attrs=None):
 
     Parameters
     ----------
-    attrs :
-        A string list of reader attributes to call. If specified, the standard
-        reading routine will be used with each attribute specified called.
+    attrs : dict, optional
+        A dictionary of attributes to call on the reader. Keys of dictionary are
+        the attribute/method names and values are the arguments passed to those
+        calls. If you do not have any attributes to call, pass ``None`` as the
+        value.
     """
     filename = os.path.abspath(os.path.expanduser(filename))
     ext = get_ext(filename)

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -182,7 +182,7 @@ def read(filename, attrs=None):
     raise IOError("This file was not able to be automatically read by vtki.")
 
 
-def load_texture(filename):
+def read_texture(filename):
     """Loads a ``vtkTexture`` from an image file."""
     filename = os.path.abspath(os.path.expanduser(filename))
     try:

--- a/vtki/readers.py
+++ b/vtki/readers.py
@@ -1,0 +1,158 @@
+"""
+Contains a dictionary that maps file extensions to VTK readers
+"""
+import os
+
+import vtk
+import vtki
+
+
+READERS = {
+    # Standard dataset readers:
+    '.vtk': vtk.vtkDataSetReader,
+    '.vti': vtk.vtkXMLImageDataReader,
+    '.vtr': vtk.vtkXMLRectilinearGridReader,
+    '.vtu': vtk.vtkXMLUnstructuredGridReader,
+    '.ply': vtk.vtkPLYReader,
+    '.obj': vtk.vtkOBJReader,
+    '.stl': vtk.vtkSTLReader,
+    '.vts': vtk.vtkXMLStructuredGridReader,
+    '.vtm': vtk.vtkXMLMultiBlockDataReader,
+    '.vtmb': vtk.vtkXMLMultiBlockDataReader,
+    # Image formats:
+    '.bmp': vtk.vtkBMPReader,
+    '.dem': vtk.vtkDEMReader,
+    '.dcm': vtk.vtkDICOMImageReader,
+    '.jpeg': vtk.vtkJPEGReader,
+    '.jpg': vtk.vtkJPEGReader,
+    '.png': vtk.vtkPNGReader,
+    '.pnm': vtk.vtkPNMReader,
+    '.slc': vtk.vtkSLCReader,
+    '.tiff': vtk.vtkTIFFReader,
+    '.tif': vtk.vtkTIFFReader,
+}
+
+
+def get_ext(filename):
+    """Extract the extension of the filename"""
+    ext = os.path.splitext(filename)[1].lower()
+    return ext
+
+
+def get_reader(filename):
+    """Gets the corresponding reader based on file extension and instantiates it
+    """
+    ext = get_ext(filename)
+    return READERS[ext]() # Get and instantiate the reader
+
+
+def standard_reader_routine(reader, filename, attrs=None):
+    """Use a given reader from the ``READERS`` mapping in the common VTK reading
+    pipeline routine.
+
+    Parameters
+    ----------
+    reader : vtkReader
+        Any instantiated VTK reader class
+
+    filename : str
+        The string filename to the data file to read.
+
+    attrs : dict, optional
+        A dictionary of attributes to call on the reader. Keys of dictionary are
+        the attribute/method names and values are the arguments passed to those
+        calls. If you do not have any attributes to call, pass ``None`` as the
+        value.
+    """
+    if attrs is None:
+        attrs = {}
+    if not isinstance(attrs, dict):
+        raise TypeError('Attributes must be a dictionary of name and arguments.')
+    reader.SetFileName(filename)
+    # Apply any attributes listed
+    for name, args in attrs.items():
+        attr = getattr(reader, name)
+        if args is not None:
+            if not isinstance(args, (list, tuple)):
+                args = [args]
+            attr(*args)
+        else:
+            attr()
+    # Perform the read
+    reader.Update()
+    return vtki.wrap(reader.GetOutputDataObject(0))
+
+
+
+def read_legacy(filename):
+    """Use VTK's legacy reader to read a file"""
+    reader = vtk.vtkDataSetReader()
+    reader.SetFileName(filename)
+    # Ensure all data is fetched with poorly formated legacy files
+    reader.ReadAllScalarsOn()
+    reader.ReadAllColorScalarsOn()
+    reader.ReadAllNormalsOn()
+    reader.ReadAllTCoordsOn()
+    reader.ReadAllVectorsOn()
+    # Perform the read
+    reader.Update()
+    return reader.GetOutputDataObject(0)
+
+
+def read(filename, attrs=None):
+    """This will read any VTK file! It will figure out what reader to use
+    then wrap the VTK object for use in ``vtki``.
+
+    Parameters
+    ----------
+    attrs :
+        A string list of reader attributes to call. If specified, the standard
+        reading routine will be used with each attribute specified called.
+    """
+    filename = os.path.abspath(os.path.expanduser(filename))
+    ext = get_ext(filename)
+
+    # From the extension, decide which reader to use
+    if attrs is not None:
+        reader = get_reader(filename)
+        return standard_reader_routine(reader, filename, attrs=attrs)
+    elif ext in '.vti': # ImageData
+        return vtki.UniformGrid(filename)
+    elif ext in '.vtr': # RectilinearGrid
+        return vtki.RectilinearGrid(filename)
+    elif ext in '.vtu': # UnstructuredGrid
+        return vtki.UnstructuredGrid(filename)
+    elif ext in ['.ply', '.obj', '.stl']: # PolyData
+        return vtki.PolyData(filename)
+    elif ext in '.vts': # StructuredGrid
+        return vtki.StructuredGrid(filename)
+    elif ext in ['.vtm', '.vtmb']:
+        return vtki.MultiBlock(filename)
+    elif ext in ['.vtk']:
+        # Attempt to use the legacy reader...
+        output = vtki.wrap(read_legacy(filename))
+        if output is None:
+            raise AssertionError('No output when using VTKs legacy reader')
+        return output
+    else:
+        # Attempt find a reader in the readers mapping
+        try:
+            reader = get_reader(filename)
+            return standard_reader_routine(reader, filename)
+        except KeyError:
+            pass
+    raise IOError("This file was not able to be automatically read by vtki.")
+
+
+def load_texture(filename):
+    """Loads a ``vtkTexture`` from an image file."""
+    filename = os.path.abspath(os.path.expanduser(filename))
+    try:
+        # intitialize the reader using the extnesion to find it
+        reader = get_reader(filename)
+    except KeyError:
+        # Otherwise, use the imageio reader
+        return vtki.numpy_to_texture(imageio.imread(filename))
+    reader.SetFileName(filename)
+    reader.Update()
+    return vtki.image_to_texture(reader.GetOutputDataObject(0))


### PR DESCRIPTION
This PR creates a way to support all VTK reader classes by mapping them to file extensions.

This creates a standard routine for reading any VTK supported file with just a few lines of code and without having to remember the proper VTK classes for performing those reads.

Find the dictionary mapping the extensions to the proper VTK reader classes in `readers.py`.

```python
import vtki
filename = 'path/to/my/file.ext'
data = vtki.read(filename)
```

Perhaps you need some flexibility with what the reader performs and need to call several setters/options on the reader - then simply pass a dictionary of function names and parameters to pass:

```python
import vtki
filename = 'path/to/my/file.ext'
data = vtki.read(filename, attrs={'DebugOn':None, 'SetScalarsName':'foo'})
```

**NOTES**: 

- Time-varying readers are not yet supported in this but could be implemented down the road
- These need to be double checked by people familiar with all the different formats
- The list of readers is not complete but creates a simple framework to add new ones by simply adding a key-value pair in the `READERS` dictionary.